### PR TITLE
BUGFIX: default value of argparse for "--deps" is boolean; breaks

### DIFF
--- a/deps_rocker/dependencies.py
+++ b/deps_rocker/dependencies.py
@@ -176,14 +176,14 @@ class Dependencies(RockerExtension):
 
     @staticmethod
     def register_arguments(parser, defaults=None):
-        parser.add_argument("--deps", action="store_true", help="install all deps.yaml ")
-        # parser.add_argument(
-        #     "--deps",
-        #     type=str,
-        #     nargs="?",
-        #     const="*.deps.yaml",
-        #     help="A filter to select deps.yaml files. Defaults to *.deps.yaml",
-        # )
+        # parser.add_argument("--deps", action="store_true", help="install all deps.yaml ")
+        parser.add_argument(
+            "--deps",
+            type=str,
+            nargs="?",
+            const="*.deps.yaml",
+            help="A filter to select deps.yaml files. Defaults to *.deps.yaml",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://github.com/blooop/deps_rocker/blob/01fd98bacd51ed9856623507b85975975c0f90f9/deps_rocker/dependencies.py#L179

This sets the key-value for deps in the cliargs dict to be {"deps": True}, which leads to failure when doing rglob here: https://github.com/blooop/deps_rocker/blob/main/deps_rocker/dependencies.py#L41, as it tries to glob the boolean. 

Commenting line #L179 and uncommenting #L180-L186 worked for me.