### PR TITLE
pyproject toml files without "project" tag

### DIFF
--- a/deps_rocker/dependencies.py
+++ b/deps_rocker/dependencies.py
@@ -151,15 +151,16 @@ class Dependencies(RockerExtension):
         for p in pp_toml:
             with open(p, "r", encoding="utf-8") as f:
                 config = toml.load(f)
-                project = config["project"]
-                if "dependencies" in project:
-                    pyproj_deps.extend(project["dependencies"])
-                if "optional-dependencies" in project:
-                    optional = project["optional-dependencies"]
-                    if "test" in optional:
-                        pyproj_deps.extend(optional["test"])
-                    if "dev" in optional:
-                        pyproj_deps.extend(optional["dev"])
+                if "project" in config:
+                    project = config["project"]
+                    if "dependencies" in project:
+                        pyproj_deps.extend(project["dependencies"])
+                    if "optional-dependencies" in project:
+                        optional = project["optional-dependencies"]
+                        if "test" in optional:
+                            pyproj_deps.extend(optional["test"])
+                        if "dev" in optional:
+                            pyproj_deps.extend(optional["dev"])
         return " ".join(pyproj_deps)
 
     def get_preamble(self, cliargs):
@@ -176,14 +177,14 @@ class Dependencies(RockerExtension):
 
     @staticmethod
     def register_arguments(parser, defaults=None):
-        parser.add_argument("--deps", action="store_true", help="install all deps.yaml ")
-        # parser.add_argument(
-        #     "--deps",
-        #     type=str,
-        #     nargs="?",
-        #     const="*.deps.yaml",
-        #     help="A filter to select deps.yaml files. Defaults to *.deps.yaml",
-        # )
+        # parser.add_argument("--deps", action="store_true", help="install all deps.yaml ")
+        parser.add_argument(
+            "--deps",
+            type=str,
+            nargs="?",
+            const="*.deps.yaml",
+            help="A filter to select deps.yaml files. Defaults to *.deps.yaml",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Not valid to assume all pyproject.toml files will have a "project" tag. e.g. https://github.com/Gepetto/example-robot-data/blob/master/pyproject.toml;
This PR does not fix dependency resolving for these non-conventional toml files, but avoids failure when such projects exist in the workspace.