### PR TITLE
check paths exist before opening

### DIFF
--- a/deps_rocker/dependencies.py
+++ b/deps_rocker/dependencies.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from collections import defaultdict
+import logging
 import yaml
 import toml
 from rocker.extensions import RockerExtension
@@ -130,14 +131,17 @@ class Dependencies(RockerExtension):
         scripts_deps = self.get_deps(name)
         if len(scripts_deps) > 0:
             for s in scripts_deps.split(" "):
-                with open(s, encoding="utf-8") as f:
-                    scripts.extend(f.readlines())
+                script_path = Path(s)
+                if script_path.is_file():
+                    with script_path.open(encoding="utf-8") as f:
+                        scripts.extend(f.readlines())
 
         if len(scripts) > 1:
             combined = "\n".join(scripts)
             combined = combined.replace("sudo ", "")
             combined = combined.replace("sudo", "")
             return combined
+        logging.warning("No deps were found to install")
         return ""
 
     def get_pyproject_toml_deps(self) -> str:


### PR DESCRIPTION
## Summary by Sourcery

Check if file paths exist before opening them to prevent errors and add a warning log when no dependencies are found.

Bug Fixes:
- Ensure file paths exist before attempting to open them, preventing potential errors.

Enhancements:
- Add a warning log message when no dependencies are found to install.