### PR TITLE
add docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "23"
+    # rust: "1.82"
+    # golang: "1.23"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary by Sourcery

Add a Read the Docs configuration file to set up the documentation build environment using Sphinx and specify Python dependencies.

Build:
- Add a Read the Docs configuration file to specify the build environment and dependencies for documentation.

Documentation:
- Configure Read the Docs to build documentation using Sphinx with specified Python requirements.