### PR TITLE
hack: add dep-rocker as a requirement for building the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+deps-rocker
 sphinxcontrib-napoleon
 sphinx-rtd-theme
 sphinx-autoapi


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add dep-rocker as a requirement in the docs/requirements.txt file.