### PR TITLE
Feature/isaacsim4.5

### DIFF
--- a/deps_rocker/templates/isaacsim_snippet.Dockerfile
+++ b/deps_rocker/templates/isaacsim_snippet.Dockerfile
@@ -11,4 +11,4 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
-RUN pip install isaacsim==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 isaacsim-extscache-physics==4.2.0.2
+RUN pip install isaacsim[all,extscache]==4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deps_rocker"
-version = "0.7.0"
+version = "0.8.0"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A rocker plugin to help installing apt and pip dependencies"
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Isaac Sim to 4.5.0 and bump version to 0.8.0.

Build:
- Update Isaac Sim installation in the Dockerfile to 4.5.0.

Chores:
- Bump project version to 0.8.0.