### PR TITLE
remove unused extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,15 +3,10 @@
     "ms-python.python",
     "ms-python.vscode-pylance",
     "ms-python.pylint",
-    "ms-python.black-formatter",
-    "njpwerner.autodocstring",
     "charliermarsh.ruff",
     "mhutchie.git-graph",
-    "eamodio.gitlens",
     "tamasfe.even-better-toml",
-    "Codium.codium",
     "ms-azuretools.vscode-docker",
-    "ryanluker.vscode-coverage-gutters",
     "jjjermiah.pixi-vscode"
   ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove unused VSCode extensions from .vscode/extensions.json