### PR TITLE
this fixes the docker-outside-docker for 22.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,11 +21,11 @@
               ]
         }
     },
-	"features": {
+    "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     },
     "mounts": [
         "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume"
     ],
-    "postCreateCommand": "sudo chown vscode .pixi && pixi install && echo '{}' > ~/.docker/config.json"
+    "postCreateCommand": "sudo chown vscode .pixi && pixi install && echo '{}' > ~/.docker/config.json || true"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,5 +27,5 @@
     "mounts": [
         "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume"
     ],
-    "postCreateCommand": "sudo chown vscode .pixi && pixi install"
+    "postCreateCommand": "sudo chown vscode .pixi && pixi install && echo '{}' > ~/.docker/config.json"
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update .devcontainer/devcontainer.json to adjust Docker socket mounting and related settings for 22.04