### PR TITLE
depend on git and curl

### DIFF
--- a/deps_rocker/extensions/lazygit/lazygit.py
+++ b/deps_rocker/extensions/lazygit/lazygit.py
@@ -5,4 +5,4 @@ class Lazygit(SimpleRockerExtension):
     """Install lazygit for interactive git operations"""
 
     name = "lazygit"
-    depends_on_extension = ("curl", "git_clone")
+    depends_on_extension = ("curl", "git", "git_clone")

--- a/deps_rocker/extensions/lazygit/lazygit_snippet.Dockerfile
+++ b/deps_rocker/extensions/lazygit/lazygit_snippet.Dockerfile
@@ -1,6 +1,3 @@
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git \
-&& apt-get clean && rm -rf /var/lib/apt/lists/*
-
 RUN LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*') \
 && echo "Lazygit version: ${LAZYGIT_VERSION}" \
 && curl -Lo lazygit.tar.gz -L "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" \


### PR DESCRIPTION
## Summary by Sourcery

Make the lazygit extension rely on existing git and curl extensions instead of installing system packages directly

Enhancements:
- Add “git” to the lazygit extension’s depends_on_extension list

Chores:
- Remove direct apt-get installation of curl, ca-certificates, and git from the lazygit Dockerfile snippet