### PR TITLE
Feature/builder cleanup

### DIFF
--- a/deps_rocker/extensions/cargo/cargo.py
+++ b/deps_rocker/extensions/cargo/cargo.py
@@ -6,8 +6,3 @@ class Cargo(SimpleRockerExtension):
 
     name = "cargo"
     depends_on_extension = ("curl",)
-
-    # Template arguments for both snippets
-    empty_args = {
-        "CARGO_VERSION": "1.90.0",
-    }

--- a/deps_rocker/extensions/cargo/cargo.py
+++ b/deps_rocker/extensions/cargo/cargo.py
@@ -8,6 +8,6 @@ class Cargo(SimpleRockerExtension):
     depends_on_extension = ("curl",)
 
     # Template arguments for both snippets
-    empy_args = {
-        "cargo_version": "1.77.2",
+    empty_args = {
+        "CARGO_VERSION": "1.77.2",
     }

--- a/deps_rocker/extensions/cargo/cargo.py
+++ b/deps_rocker/extensions/cargo/cargo.py
@@ -9,5 +9,5 @@ class Cargo(SimpleRockerExtension):
 
     # Template arguments for both snippets
     empty_args = {
-        "CARGO_VERSION": "1.77.2",
+        "CARGO_VERSION": "1.90.0",
     }

--- a/deps_rocker/extensions/cargo/cargo.py
+++ b/deps_rocker/extensions/cargo/cargo.py
@@ -11,7 +11,3 @@ class Cargo(SimpleRockerExtension):
     empy_args = {
         "cargo_version": "1.77.2",
     }
-
-    empy_builder_args = {
-        "cargo_version": "1.77.2",
-    }

--- a/deps_rocker/extensions/cargo/cargo_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/cargo/cargo_builder_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG CARGO_VERSION=@cargo_version@
+ARG CARGO_VERSION=@CARGO_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/cargo/cargo_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/cargo/cargo_builder_snippet.Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.4
-ARG CARGO_VERSION=@CARGO_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/cargo/cargo_snippet.Dockerfile
+++ b/deps_rocker/extensions/cargo/cargo_snippet.Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.4
-ARG CARGO_VERSION=@CARGO_VERSION@
 
 # Install Rust toolchain from cached builder stage
 @(f"COPY --from={builder_stage} {builder_output_dir}/root/.cargo /root/.cargo")

--- a/deps_rocker/extensions/cargo/cargo_snippet.Dockerfile
+++ b/deps_rocker/extensions/cargo/cargo_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG CARGO_VERSION=@cargo_version@
+ARG CARGO_VERSION=@CARGO_VERSION@
 
 # Install Rust toolchain from cached builder stage
 @(f"COPY --from={builder_stage} {builder_output_dir}/root/.cargo /root/.cargo")

--- a/deps_rocker/extensions/conda/conda.py
+++ b/deps_rocker/extensions/conda/conda.py
@@ -9,6 +9,6 @@ class Conda(SimpleRockerExtension):
 
     # Template arguments for both snippets
     empy_args = {
-        "miniforge_version": "latest",
-        "conda_version": "24.3.0-0",
+        "MINIFORGE_VERSION": "latest",
+        "CONDA_VERSION": "24.3.0-0",
     }

--- a/deps_rocker/extensions/conda/conda.py
+++ b/deps_rocker/extensions/conda/conda.py
@@ -12,8 +12,3 @@ class Conda(SimpleRockerExtension):
         "miniforge_version": "latest",
         "conda_version": "24.3.0-0",
     }
-
-    empy_builder_args = {
-        "miniforge_version": "latest",
-        "conda_version": "24.3.0-0",
-    }

--- a/deps_rocker/extensions/conda/conda_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/conda/conda_builder_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG CONDA_VERSION=@conda_version@
+ARG CONDA_VERSION=@CONDA_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/conda/conda_snippet.Dockerfile
+++ b/deps_rocker/extensions/conda/conda_snippet.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
-ARG MINIFORGE_VERSION=@miniforge_version@
-ARG CONDA_VERSION=@conda_version@
+ARG MINIFORGE_VERSION=@MINIFORGE_VERSION@
+ARG CONDA_VERSION=@CONDA_VERSION@
 
 ENV CONDA_DIR=/opt/miniconda3
 

--- a/deps_rocker/extensions/fzf/fzf.py
+++ b/deps_rocker/extensions/fzf/fzf.py
@@ -9,5 +9,5 @@ class Fzf(SimpleRockerExtension):
 
     # Template arguments for both snippets
     empy_args = {
-        "fzf_version": "0.53.0",
+        "FZF_VERSION": "0.53.0",
     }

--- a/deps_rocker/extensions/fzf/fzf.py
+++ b/deps_rocker/extensions/fzf/fzf.py
@@ -11,7 +11,3 @@ class Fzf(SimpleRockerExtension):
     empy_args = {
         "fzf_version": "0.53.0",
     }
-
-    empy_builder_args = {
-        "fzf_version": "0.53.0",
-    }

--- a/deps_rocker/extensions/fzf/fzf_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/fzf/fzf_builder_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG FZF_VERSION=@fzf_version@
+ARG FZF_VERSION=@FZF_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/fzf/fzf_snippet.Dockerfile
+++ b/deps_rocker/extensions/fzf/fzf_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG FZF_VERSION=@fzf_version@
+ARG FZF_VERSION=@FZF_VERSION@
 
 # Make fzf source available for user install step
 @(f"COPY --from={builder_stage} {builder_output_dir}/fzf /opt/deps_rocker/fzf")

--- a/deps_rocker/extensions/lazygit/lazygit.py
+++ b/deps_rocker/extensions/lazygit/lazygit.py
@@ -9,5 +9,5 @@ class Lazygit(SimpleRockerExtension):
 
     # Template arguments for both snippets
     empy_args = {
-        "lazygit_version": "0.41.0",
+        "LAZYGIT_VERSION": "0.41.0",
     }

--- a/deps_rocker/extensions/lazygit/lazygit.py
+++ b/deps_rocker/extensions/lazygit/lazygit.py
@@ -11,7 +11,3 @@ class Lazygit(SimpleRockerExtension):
     empy_args = {
         "lazygit_version": "0.41.0",
     }
-
-    empy_builder_args = {
-        "lazygit_version": "0.41.0",
-    }

--- a/deps_rocker/extensions/lazygit/lazygit_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/lazygit/lazygit_builder_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG LAZYGIT_VERSION=@lazygit_version@
+ARG LAZYGIT_VERSION=@LAZYGIT_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/lazygit/lazygit_snippet.Dockerfile
+++ b/deps_rocker/extensions/lazygit/lazygit_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG LAZYGIT_VERSION=@lazygit_version@
+ARG LAZYGIT_VERSION=@LAZYGIT_VERSION@
 
 # Copy lazygit binary built in the builder stage
 @(f"COPY --from={builder_stage} {builder_output_dir}/lazygit /usr/local/bin/lazygit")

--- a/deps_rocker/extensions/npm/npm.py
+++ b/deps_rocker/extensions/npm/npm.py
@@ -8,7 +8,6 @@ class Npm(SimpleRockerExtension):
     depends_on_extension = ("curl",)
 
     empy_args = {
-        "node_version": "24.9.0",
-        "npm_version": "11.6.1",
+        "NODE_VERSION": "24.9.0",
+        "NPM_VERSION": "11.6.1",
     }
-

--- a/deps_rocker/extensions/npm/npm.py
+++ b/deps_rocker/extensions/npm/npm.py
@@ -10,12 +10,5 @@ class Npm(SimpleRockerExtension):
     empy_args = {
         "node_version": "24.9.0",
         "npm_version": "11.6.1",
-        "builder_output_dir": "/opt/deps_rocker/npm",
-        "builder_stage": "npm_builder",
     }
 
-    empy_builder_args = {
-        "node_version": "24.9.0",
-        "builder_output_dir": "/opt/deps_rocker/npm",
-        "builder_stage": "npm_builder",
-    }

--- a/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG NODE_VERSION=@node_version@
+ARG NODE_VERSION=@NODE_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/npm/npm_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_snippet.Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p $NVM_DIR
 RUN bash /tmp/install.sh
 
 # Install node and npm using nvm, then upgrade npm to specific version
-RUN bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION && npm install -g npm@@$NPM_VERSION"
+RUN bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION && npm install -g npm@$NPM_VERSION"
 
 # Verify installed npm version
 RUN bash -c "source $NVM_DIR/nvm.sh && echo 'Installed npm version:' && npm --version"

--- a/deps_rocker/extensions/npm/npm_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_snippet.Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p $NVM_DIR
 RUN bash /tmp/install.sh
 
 # Install node and npm using nvm, then upgrade npm to specific version
-RUN bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION && npm install -g npm@$NPM_VERSION"
+RUN bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION && npm install -g npm@@$NPM_VERSION"
 
 # Verify installed npm version
 RUN bash -c "source $NVM_DIR/nvm.sh && echo 'Installed npm version:' && npm --version"

--- a/deps_rocker/extensions/pixi/pixi.py
+++ b/deps_rocker/extensions/pixi/pixi.py
@@ -9,5 +9,5 @@ class Pixi(SimpleRockerExtension):
 
     # Template arguments for both snippets
     empy_args = {
-        "pixi_version": "0.55.0",
+        "PIXI_VERSION": "0.55.0",
     }

--- a/deps_rocker/extensions/pixi/pixi.py
+++ b/deps_rocker/extensions/pixi/pixi.py
@@ -11,7 +11,3 @@ class Pixi(SimpleRockerExtension):
     empy_args = {
         "pixi_version": "0.55.0",
     }
-
-    empy_builder_args = {
-        "pixi_version": "0.55.0",
-    }

--- a/deps_rocker/extensions/pixi/pixi_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/pixi/pixi_builder_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-@(f"ARG PIXI_VERSION={pixi_version}")
+@(f"ARG PIXI_VERSION={PIXI_VERSION}")
 
 @(f"FROM {base_image} AS {builder_stage}")
 

--- a/deps_rocker/extensions/pixi/pixi_snippet.Dockerfile
+++ b/deps_rocker/extensions/pixi/pixi_snippet.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-@(f"ARG PIXI_VERSION={pixi_version}")
+@(f"ARG PIXI_VERSION={PIXI_VERSION}")
 
 # Provide Pixi installation bundle for user stage
 @(f"COPY --from={builder_stage} {builder_output_dir}/.pixi /opt/deps_rocker/pixi")

--- a/deps_rocker/simple_rocker_extension.py
+++ b/deps_rocker/simple_rocker_extension.py
@@ -30,10 +30,46 @@ class SimpleRockerExtensionMeta(type):
 class SimpleRockerExtension(RockerExtension, metaclass=SimpleRockerExtensionMeta):
     """A class to take care of most of the boilerplace required for a rocker extension"""
 
+    @property
+    def builder_output_dir(self):
+        return f"/opt/deps_rocker/{self.name}"
+
+    @property
+    def builder_stage(self):
+        return f"{self.name}_builder"
+
+    @property
+    def empy_args_with_builder(self):
+        # Always include builder_output_dir and builder_stage
+        args = dict(self.empy_args)
+        args.setdefault("builder_output_dir", self.builder_output_dir)
+        args.setdefault("builder_stage", self.builder_stage)
+        return args
+
+    @property
+    def empy_builder_args_with_builder(self):
+        # Always include builder_output_dir and builder_stage
+        args = dict(self.empy_builder_args)
+        args.setdefault("builder_output_dir", self.builder_output_dir)
+        args.setdefault("builder_stage", self.builder_stage)
+        return args
+
     name = "simple_rocker_extension"
     empy_args = {}
     empy_user_args = {}
-    empy_builder_args = {}
+    _empy_builder_args = None  # Internal storage for explicit builder args
+
+    @property
+    def empy_builder_args(self):
+        # If explicitly set, use it; otherwise, default to empy_args
+        if self._empy_builder_args is not None:
+            return self._empy_builder_args
+        return self.empy_args
+
+    @empy_builder_args.setter
+    def empy_builder_args(self, value):
+        self._empy_builder_args = value
+
     depends_on_extension: tuple[str, ...] = ()  # Tuple of dependencies required by the extension
     apt_packages: list[str] = []  # List of apt packages required by the extension
     builder_output_root = "/opt/deps_rocker"

--- a/deps_rocker/simple_rocker_extension.py
+++ b/deps_rocker/simple_rocker_extension.py
@@ -38,37 +38,33 @@ class SimpleRockerExtension(RockerExtension, metaclass=SimpleRockerExtensionMeta
     def builder_stage(self):
         return f"{self.name}_builder"
 
+    def _with_builder_defaults(self, raw: dict) -> dict:
+        out = dict(raw)
+        out.setdefault("builder_output_dir", self.builder_output_dir)
+        out.setdefault("builder_stage", self.builder_stage)
+        return out
+
     @property
     def empy_args_with_builder(self):
-        # Always include builder_output_dir and builder_stage
-        args = dict(self.empy_args)
-        args.setdefault("builder_output_dir", self.builder_output_dir)
-        args.setdefault("builder_stage", self.builder_stage)
-        return args
+        return self._with_builder_defaults(self.empy_args)
 
     @property
     def empy_builder_args_with_builder(self):
-        # Always include builder_output_dir and builder_stage
-        args = dict(self.empy_builder_args)
-        args.setdefault("builder_output_dir", self.builder_output_dir)
-        args.setdefault("builder_stage", self.builder_stage)
-        return args
+        return self._with_builder_defaults(self.empy_builder_args)
 
     name = "simple_rocker_extension"
     empy_args = {}
     empy_user_args = {}
-    _empy_builder_args = None  # Internal storage for explicit builder args
 
     @property
     def empy_builder_args(self):
-        # If explicitly set, use it; otherwise, default to empy_args
-        if self._empy_builder_args is not None:
-            return self._empy_builder_args
-        return self.empy_args
+        # If someone overwrote empy_builder_args on the instance, use it; otherwise fall back to empy_args
+        return getattr(self, "__empy_builder_args", self.empy_args)
 
     @empy_builder_args.setter
-    def empy_builder_args(self, value):
-        self._empy_builder_args = value
+    def empy_builder_args(self, value: dict):
+        # store directly on instance, avoids separate _empy_builder_args attr
+        object.__setattr__(self, "__empy_builder_args", value)
 
     depends_on_extension: tuple[str, ...] = ()  # Tuple of dependencies required by the extension
     apt_packages: list[str] = []  # List of apt packages required by the extension


### PR DESCRIPTION
## Summary by Sourcery

Centralize builder argument handling in SimpleRockerExtension and remove duplicated empy_builder_args definitions from individual extensions.

New Features:
- Add builder_output_dir and builder_stage computed properties in SimpleRockerExtension
- Introduce empy_args_with_builder and empy_builder_args_with_builder properties to include builder args automatically

Enhancements:
- Allow explicit override of empy_builder_args via a setter while defaulting to empy_args
- Remove redundant empy_builder_args definitions from npm, conda, cargo, fzf, lazygit, and pixi extensions
- Update npm extension argument keys to uppercase NODE_VERSION and NPM_VERSION