### PR TITLE
Feature/uv cache

### DIFF
--- a/deps_rocker/extensions/uv/uv.py
+++ b/deps_rocker/extensions/uv/uv.py
@@ -5,9 +5,3 @@ class UV(SimpleRockerExtension):
     """Add the uv package manager to your docker image"""
 
     name = "uv"
-
-    # TODO enable use of cache on host machine
-    # def get_docker_args(self, cliargs):
-    #     # abs = Path("$HOME/.cache/uv").absolute().as_posix()
-    #     abs = "$HOME/.cache/uv"
-    #     return f"-v {abs}:{abs}"

--- a/deps_rocker/extensions/uv/uv_snippet.Dockerfile
+++ b/deps_rocker/extensions/uv/uv_snippet.Dockerfile
@@ -1,1 +1,15 @@
+
+
+
+# syntax=docker/dockerfile:1.4
+# FROM {base_image} AS {builder_stage}  # Provided by main Dockerfile or template engine
+
+# Use BuildKit cache for uv cache directory, with a unique id for sharing
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache \
+	echo "BuildKit cache for uv enabled at /root/.cache/uv"
+
+# Copy uv binaries from official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Optionally, test uv is available (not strictly needed for build, but for debug)
+RUN uv --version

--- a/deps_rocker/extensions/uv/uv_snippet.Dockerfile
+++ b/deps_rocker/extensions/uv/uv_snippet.Dockerfile
@@ -1,15 +1,8 @@
-
-
-
 # syntax=docker/dockerfile:1.4
-# FROM {base_image} AS {builder_stage}  # Provided by main Dockerfile or template engine
 
 # Use BuildKit cache for uv cache directory, with a unique id for sharing
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache \
 	echo "BuildKit cache for uv enabled at /root/.cache/uv"
 
-# Copy uv binaries from official image
+# Copy uv,uvx binaries from official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
-# Optionally, test uv is available (not strictly needed for build, but for debug)
-RUN uv --version

--- a/specs/01/uv/plan.md
+++ b/specs/01/uv/plan.md
@@ -1,0 +1,22 @@
+# Plan: UV Extension BuildKit Cache Integration
+
+## Goal
+Enable the `uv` extension to use BuildKit cache mounts for a shared cache, improving build efficiency and reducing redundant downloads.
+
+## Steps
+1. **Update Dockerfile Snippet**
+   - Add `RUN --mount=type=cache,target=/root/.cache/uv` to the uv installation step in the Dockerfile snippet.
+   - Ensure the cache is versioned if possible (e.g., by uv version).
+2. **Update Extension Logic**
+   - Confirm the extension class and logic remain compatible with the new Dockerfile snippet.
+3. **Testing**
+   - Update or verify the test.sh script to check that uv works and the cache directory is used.
+   - Run tests to ensure the extension installs and functions as expected.
+4. **CI and Commit**
+   - Run `pixi run ci` and fix any errors.
+   - Commit and push changes using `pixi r fix-commit-push`.
+
+## Acceptance Criteria
+- The Dockerfile for uv uses a BuildKit cache mount for `/root/.cache/uv`.
+- The extension passes all tests and CI checks.
+- The cache is reused between builds, as verified by test.sh or build logs.

--- a/specs/01/uv/spec.md
+++ b/specs/01/uv/spec.md
@@ -1,0 +1,7 @@
+# UV Extension: BuildKit Cache Mounts
+
+The `uv` extension must leverage BuildKit cache mounts to enable a shared cache for improved efficiency during installation and dependency resolution. This ensures that repeated builds reuse cached downloads and artifacts, minimizing redundant network operations and speeding up container builds.
+
+- Use `RUN --mount=type=cache,target=/root/.cache/uv` in the Dockerfile snippet for uv installation.
+- The cache should persist between builds and be versioned if possible.
+- The extension must remain compatible with the existing deps_rocker extension system.


### PR DESCRIPTION
## Summary by Sourcery

Integrate BuildKit cache support into the uv extension by updating its Dockerfile snippet and formalizing the cache integration requirements through new plan and spec documentation.

New Features:
- Enable BuildKit cache mount for /root/.cache/uv in the uv extension Dockerfile snippet

Enhancements:
- Remove outdated get_docker_args placeholder code from the uv extension class

Documentation:
- Add plan and spec documents to specify BuildKit cache integration requirements for the uv extension