### PR TITLE
Feature/node cache

### DIFF
--- a/deps_rocker/extensions/auto/auto.py
+++ b/deps_rocker/extensions/auto/auto.py
@@ -21,8 +21,6 @@ class Auto(SimpleRockerExtension):
             help="Directory to start recursive search for project files (overrides default root)",
         )
 
-    """Automatically detect and enable extensions based on workspace files"""
-
     name = "auto"
 
     def _detect_files_in_workspace(self, _cliargs: dict) -> set[str]:

--- a/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
@@ -3,20 +3,28 @@ ARG NODE_VERSION=@NODE_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 
+ARG NODE_VERSION
 ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=${NODE_VERSION}
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates && \
+    apt-get install -y --no-install-recommends curl ca-certificates git && \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/tmp/nvm-install-cache,id=nvm-install-cache \
-    bash -c "set -euxo pipefail && \
-    mkdir -p /tmp/nvm-install-cache && \
-    mkdir -p /opt/deps_rocker/npm && \
-    if [ ! -f /tmp/nvm-install-cache/install.sh ]; then \
-        curl -sS -o /tmp/nvm-install-cache/install.sh https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh; \
+# Clone nvm from git with caching
+RUN --mount=type=cache,target=/tmp/nvm-git-cache,id=nvm-git-cache \
+    bash -c "set -e && \
+    if [ -d /tmp/nvm-git-cache/.git ]; then \
+        cd /tmp/nvm-git-cache && git fetch --tags && git checkout v0.40.0; \
+    else \
+        git clone https://github.com/nvm-sh/nvm.git /tmp/nvm-git-cache && \
+        cd /tmp/nvm-git-cache && git checkout v0.40.0; \
     fi && \
-    cp /tmp/nvm-install-cache/install.sh /opt/deps_rocker/npm/install.sh"
+    cp -r /tmp/nvm-git-cache /usr/local/nvm"
+
+# Install Node.js using nvm with cached downloads - use template substitution for version
+RUN --mount=type=cache,target=/usr/local/nvm/.cache,id=nvm-node-cache \
+    bash -c "set -e && \
+    . \$NVM_DIR/nvm.sh && \
+    nvm install @(NODE_VERSION)"

--- a/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
 RUN --mount=type=cache,target=/tmp/nvm-git-cache,id=nvm-git-cache \
     bash -c "set -e && \
     if [ -d /tmp/nvm-git-cache/.git ]; then \
-        cd /tmp/nvm-git-cache && git fetch --tags && git checkout v0.40.0; \
+        cd /tmp/nvm-git-cache && git fetch --tags && git checkout v0.40.3; \
     else \
         git clone https://github.com/nvm-sh/nvm.git /tmp/nvm-git-cache && \
         cd /tmp/nvm-git-cache && git checkout v0.40.0; \

--- a/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_builder_snippet.Dockerfile
@@ -21,7 +21,9 @@ RUN --mount=type=cache,target=/tmp/nvm-git-cache,id=nvm-git-cache \
         git clone https://github.com/nvm-sh/nvm.git /tmp/nvm-git-cache && \
         cd /tmp/nvm-git-cache && git checkout v0.40.0; \
     fi && \
-    cp -r /tmp/nvm-git-cache /usr/local/nvm"
+    # Use tar to copy nvm cache, excluding .git, test, and .github for smaller image and security
+    # Ensure /usr/local/nvm exists before extracting
+    mkdir -p /usr/local/nvm && tar --exclude='.git' --exclude='test' --exclude='.github' -cf - -C /tmp/nvm-git-cache . | tar -xf - -C /usr/local/nvm"
 
 # Install Node.js using nvm with cached downloads - use template substitution for version
 RUN --mount=type=cache,target=/usr/local/nvm/.cache,id=nvm-node-cache \

--- a/deps_rocker/extensions/npm/npm_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_snippet.Dockerfile
@@ -1,13 +1,11 @@
 ENV NODE_VERSION=24.9.0
 # Install nvm, node and npm
 ENV NVM_DIR=/usr/local/nvm
-ENV NPM_VERSION=11.6.1
 
 # Copy pre-installed nvm directory from builder
 @(f"COPY --from={builder_stage} $NVM_DIR $NVM_DIR")
 
 # Upgrade npm to specific version
-RUN bash -c "source $NVM_DIR/nvm.sh && nvm use $NODE_VERSION && npm install -g npm@@$NPM_VERSION"
 
 # Verify installed npm version
 RUN bash -c "source $NVM_DIR/nvm.sh && echo 'Installed npm version:' && npm --version"

--- a/deps_rocker/extensions/npm/npm_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_snippet.Dockerfile
@@ -3,15 +3,11 @@ ENV NVM_DIR=/usr/local/nvm
 ENV NODE_VERSION=24.9.0
 ENV NPM_VERSION=11.6.1
 
-# Create nvm directory
-RUN mkdir -p $NVM_DIR
+# Copy pre-installed nvm directory from builder
+@(f"COPY --from={builder_stage} $NVM_DIR $NVM_DIR")
 
-# Copy nvm install script from builder output
-@(f"COPY --from={builder_stage} {builder_output_dir}/install.sh /tmp/install.sh")
-RUN bash /tmp/install.sh
-
-# Install node and npm using nvm, then upgrade npm to specific version
-RUN bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION && npm install -g npm@@$NPM_VERSION"
+# Upgrade npm to specific version
+RUN bash -c "source $NVM_DIR/nvm.sh && nvm use $NODE_VERSION && npm install -g npm@@$NPM_VERSION"
 
 # Verify installed npm version
 RUN bash -c "source $NVM_DIR/nvm.sh && echo 'Installed npm version:' && npm --version"

--- a/deps_rocker/extensions/npm/npm_snippet.Dockerfile
+++ b/deps_rocker/extensions/npm/npm_snippet.Dockerfile
@@ -1,6 +1,6 @@
+ENV NODE_VERSION=24.9.0
 # Install nvm, node and npm
 ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=24.9.0
 ENV NPM_VERSION=11.6.1
 
 # Copy pre-installed nvm directory from builder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ style = { depends-on = ["format", "lint"] }
 commit-format = "git commit -a -m'autoformat code' || true"
 test = "python -m pytest -v -s"
 test-claude = "python -m pytest -v -s -m claude"
-coverage = "coverage run -m pytest -v -s && coverage xml -o coverage.xml"
+coverage = "coverage run -m pytest --durations=0 -v -s && coverage xml -o coverage.xml"
 coverage-report = "coverage report -m"
 update-lock = "pixi update && git commit -a -m'update pixi.lock' || true"
 push = "git push"

--- a/test/test_extensions_generic.py
+++ b/test/test_extensions_generic.py
@@ -36,7 +36,7 @@ class TestExtensionsGeneric(unittest.TestCase):
         # "isaac_sim",
         # "ros_jazzy", #tested via ros_underlay
         # "vcstool", #tested via ros_underlay
-        "ros_underlay",
+        # "ros_underlay", #too slow
         "auto",
     ]
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce build-time caching and multi-stage Docker builds for NVM and Node installation by cloning NVM from GitHub, installing Node in the builder stage, and simplifying the final image to only upgrade NPM.

Enhancements:
- Replace the NVM install script download with a cached git clone of the repository and remove temporary install.sh steps
- Streamline the final image by copying the preinstalled NVM directory from the builder stage and limiting the final build to an NPM upgrade

Build:
- Add BuildKit cache mounts for apt, apt lists, NVM git clone, and NVM’s Node downloads
- Install git and clone the NVM repo at a fixed version in the builder stage
- Install Node.js via NVM in the builder stage using cached downloads