### PR TITLE
Move underlay build to user layer and simplify scripts

### DIFF
--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -62,9 +62,9 @@ RUN chmod +x /usr/local/bin/underlay_deps.sh /usr/local/bin/underlay_build.sh
 # Copy test files for the test script
 COPY test_package.xml test_setup.py /tmp/
 
-# Build the underlay workspace if it contains packages
+# Prepare underlay dependencies during build (but don't build yet)
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache \
     --mount=type=cache,target=/root/.ros/rosdep,id=rosdep-cache \
-    underlay_deps.sh && underlay_build.sh
+    underlay_deps.sh
 
 ENV COLCON_DEFAULTS_FILE=/ros_ws/colcon-defaults.yaml

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -44,9 +44,8 @@ ENV ROS_BUILD_BASE=/ros_ws/build
 ENV ROS_INSTALL_BASE=/ros_ws/install
 ENV ROS_LOG_BASE=/ros_ws/logs
 
-RUN mkdir -p "$ROS_UNDERLAY_PATH" "$ROS_UNDERLAY_BUILD" "$ROS_UNDERLAY_INSTALL" "$ROS_UNDERLAY_LOG" \
-  "$ROS_BUILD_BASE" "$ROS_INSTALL_BASE" "$ROS_LOG_BASE" \
-  && chmod -R 777 /ros_ws
+RUN install -d -m 777 "$ROS_UNDERLAY_PATH" "$ROS_UNDERLAY_BUILD" "$ROS_UNDERLAY_INSTALL" "$ROS_UNDERLAY_LOG" \
+  "$ROS_BUILD_BASE" "$ROS_INSTALL_BASE" "$ROS_LOG_BASE"
 
 # Copy the consolidated depends.repos manifest for user layer import
 COPY consolidated.repos /ros_ws/consolidated.repos

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -47,13 +47,8 @@ RUN mkdir -p "$ROS_UNDERLAY_PATH" "$ROS_UNDERLAY_BUILD" "$ROS_UNDERLAY_INSTALL" 
   "$ROS_BUILD_BASE" "$ROS_INSTALL_BASE" "$ROS_LOG_BASE" \
   && chmod -R 777 /ros_ws
 
-# Import the consolidated depends.repos manifest to underlay
+# Copy the consolidated depends.repos manifest for user layer import
 COPY consolidated.repos /ros_ws/consolidated.repos
-RUN --mount=type=cache,target=/root/.cache/vcs-repos,id=vcs-repos-cache \
-    rm -rf /root/.cache/vcs-repos/underlay && \
-    mkdir -p /root/.cache/vcs-repos/underlay && \
-    vcs import --recursive /root/.cache/vcs-repos/underlay < /ros_ws/consolidated.repos && \
-    cp -r /root/.cache/vcs-repos/underlay/. /ros_ws/underlay/
 
 # Install underlay build scripts
 COPY underlay_deps.sh underlay_build.sh /usr/local/bin/
@@ -62,9 +57,6 @@ RUN chmod +x /usr/local/bin/underlay_deps.sh /usr/local/bin/underlay_build.sh
 # Copy test files for the test script
 COPY test_package.xml test_setup.py /tmp/
 
-# Prepare underlay dependencies during build (but don't build yet)
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache \
-    --mount=type=cache,target=/root/.ros/rosdep,id=rosdep-cache \
-    underlay_deps.sh
+# Dependencies will be installed in user layer after VCS import
 
 ENV COLCON_DEFAULTS_FILE=/ros_ws/colcon-defaults.yaml

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -36,14 +36,15 @@ RUN if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then \
 
 # Define the canonical ROS workspace layout
 ENV ROS_WORKSPACE_ROOT=/ros_ws
-ENV ROS_UNDERLAY_PATH=/ros_ws/underlay
-ENV ROS_UNDERLAY_BUILD=/ros_ws/underlay_build
-ENV ROS_UNDERLAY_INSTALL=/ros_ws/underlay_install
+ENV ROS_UNDERLAY_PATH=/ros_ws/underlay/src
+ENV ROS_UNDERLAY_BUILD=/ros_ws/underlay/build
+ENV ROS_UNDERLAY_INSTALL=/ros_ws/underlay/install
+ENV ROS_UNDERLAY_LOG=/ros_ws/underlay/log
 ENV ROS_BUILD_BASE=/ros_ws/build
 ENV ROS_INSTALL_BASE=/ros_ws/install
 ENV ROS_LOG_BASE=/ros_ws/logs
 
-RUN mkdir -p "$ROS_UNDERLAY_PATH" "$ROS_UNDERLAY_BUILD" "$ROS_UNDERLAY_INSTALL" \
+RUN mkdir -p "$ROS_UNDERLAY_PATH" "$ROS_UNDERLAY_BUILD" "$ROS_UNDERLAY_INSTALL" "$ROS_UNDERLAY_LOG" \
   "$ROS_BUILD_BASE" "$ROS_INSTALL_BASE" "$ROS_LOG_BASE" \
   && chmod -R 777 /ros_ws
 

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -41,7 +41,7 @@ ENV ROS_UNDERLAY_BUILD=/ros_ws/underlay_build
 ENV ROS_UNDERLAY_INSTALL=/ros_ws/underlay_install
 ENV ROS_BUILD_BASE=/ros_ws/build
 ENV ROS_INSTALL_BASE=/ros_ws/install
-ENV ROS_LOG_BASE=/ros_ws/log
+ENV ROS_LOG_BASE=/ros_ws/logs
 
 RUN mkdir -p "$ROS_UNDERLAY_PATH" "$ROS_UNDERLAY_BUILD" "$ROS_UNDERLAY_INSTALL" \
   "$ROS_BUILD_BASE" "$ROS_INSTALL_BASE" "$ROS_LOG_BASE" \

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_user_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_user_snippet.Dockerfile
@@ -3,7 +3,7 @@ RUN --mount=type=cache,target=$HOME/.cache/vcs-repos,id=vcs-repos-cache \
     rm -rf $HOME/.cache/vcs-repos/underlay && \
     mkdir -p $HOME/.cache/vcs-repos/underlay && \
     vcs import --recursive $HOME/.cache/vcs-repos/underlay < /ros_ws/consolidated.repos && \
-    cp -r $HOME/.cache/vcs-repos/underlay/. /ros_ws/underlay/
+    cp -r $HOME/.cache/vcs-repos/underlay/. $ROS_UNDERLAY_PATH/
 
 # Install dependencies and build the underlay workspace
 RUN --mount=type=cache,target=$HOME/.ros/rosdep,id=rosdep-cache \

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_user_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_user_snippet.Dockerfile
@@ -1,6 +1,9 @@
 # Change ownership of ROS workspace directories to the user
 # This runs after the user is created, ensuring they can write to build directories
 RUN chown -R ${USER_NAME}:${USER_NAME} /ros_ws
+
+# Build the underlay workspace now that we're in the user context
+RUN underlay_build.sh
   
 #ROS user snippet
 RUN DEPS_ROOT="${ROS_DEPENDENCIES_ROOT}" && \

--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_user_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_user_snippet.Dockerfile
@@ -9,11 +9,10 @@ RUN --mount=type=cache,target=$HOME/.cache/vcs-repos,id=vcs-repos-cache \
 RUN --mount=type=cache,target=$HOME/.ros/rosdep,id=rosdep-cache \
     underlay_deps.sh && underlay_build.sh
   
-#ROS user snippet
-RUN DEPS_ROOT="${ROS_DEPENDENCIES_ROOT}" && \
-    if [ -d "$DEPS_ROOT" ]; then \
+# Install additional dependencies if ROS_DEPENDENCIES_ROOT is defined
+RUN if [ -n "${ROS_DEPENDENCIES_ROOT:-}" ] && [ -d "${ROS_DEPENDENCIES_ROOT}" ]; then \
         rosdep update && \
-        rosdep install --from-paths "$DEPS_ROOT" --ignore-src -r -y; \
+        rosdep install --from-paths "${ROS_DEPENDENCIES_ROOT}" --ignore-src -r -y; \
     fi
 
 

--- a/deps_rocker/extensions/ros_jazzy/underlay_build.sh
+++ b/deps_rocker/extensions/ros_jazzy/underlay_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build the underlay workspace
-# Can be called during Docker build or from inside the container
+# Runs in user context to avoid ownership issues
 
 set -e
 
@@ -32,56 +32,11 @@ fi
 # Create build and install directories if they don't exist
 mkdir -p "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
 
-CURRENT_UID="$(id -u)"
-CURRENT_GID="$(id -g)"
-
-ensure_owner_for_paths() {
-    local path current_owner target_owner
-    target_owner="${CURRENT_UID}:${CURRENT_GID}"
-    for path in "$@"; do
-        [ ! -e "${path}" ] && continue
-        current_owner="$(stat -c '%u:%g' "${path}")"
-        if [ "${current_owner}" = "${target_owner}" ]; then
-            continue
-        fi
-
-        if [ "${CURRENT_UID}" -eq 0 ]; then
-            chown -R "${target_owner}" "${path}"
-        elif command -v sudo >/dev/null 2>&1; then
-            sudo chown -R "${target_owner}" "${path}"
-        else
-            echo "ERROR: Unable to adjust ownership for ${path}; run as root or install sudo." >&2
-            exit 1
-        fi
-    done
-}
-
-ensure_world_accessible() {
-    local path
-    for path in "$@"; do
-        [ ! -e "${path}" ] && continue
-        if chmod -R a+rwX "${path}" 2>/dev/null; then
-            continue
-        fi
-
-        if [ "${CURRENT_UID}" -eq 0 ]; then
-            chmod -R a+rwX "${path}"
-        elif command -v sudo >/dev/null 2>&1; then
-            sudo chmod -R a+rwX "${path}"
-        else
-            echo "WARNING: Unable to adjust permissions for ${path}; some users may lack access." >&2
-        fi
-    done
-}
-
-# Ensure the active user owns the build/install directories before building so CMake can modify timestamps
-ensure_owner_for_paths "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
-
-# Clean out any stale artifacts left by previous builds (especially ones created by a different user)
-if [ -n "$(ls -A "${UNDERLAY_BUILD}")" ]; then
+# Clean out any stale artifacts from previous builds
+if [ -n "$(ls -A "${UNDERLAY_BUILD}" 2>/dev/null)" ]; then
     rm -rf "${UNDERLAY_BUILD:?}/"*
 fi
-if [ -n "$(ls -A "${UNDERLAY_INSTALL}")" ]; then
+if [ -n "$(ls -A "${UNDERLAY_INSTALL}" 2>/dev/null)" ]; then
     rm -rf "${UNDERLAY_INSTALL:?}/"*
 fi
 
@@ -94,10 +49,6 @@ colcon build \
     --install-base "${UNDERLAY_INSTALL}" \
     --merge-install \
     --cmake-args -DCMAKE_BUILD_TYPE=Release
-
-# Ensure built artifacts are accessible/writeable by all users. CMake expects to be able to update timestamps,
-# so we need both ownership (handled above) and world-readable/executable bits for follow-up consumers.
-ensure_world_accessible "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
 
 echo "Underlay built successfully"
 echo "Source with: source ${UNDERLAY_INSTALL}/setup.bash"

--- a/deps_rocker/extensions/ros_jazzy/underlay_build.sh
+++ b/deps_rocker/extensions/ros_jazzy/underlay_build.sh
@@ -5,9 +5,9 @@
 set -e
 
 # Use workspace layout from environment
-UNDERLAY_PATH="${ROS_UNDERLAY_PATH:-/ros_ws/underlay}"
-UNDERLAY_BUILD="${ROS_UNDERLAY_BUILD:-/ros_ws/underlay_build}"
-UNDERLAY_INSTALL="${ROS_UNDERLAY_INSTALL:-/ros_ws/underlay_install}"
+UNDERLAY_PATH="${ROS_UNDERLAY_PATH:-/ros_ws/underlay/src}"
+UNDERLAY_BUILD="${ROS_UNDERLAY_BUILD:-/ros_ws/underlay/build}"
+UNDERLAY_INSTALL="${ROS_UNDERLAY_INSTALL:-/ros_ws/underlay/install}"
 WORKSPACE_ROOT="${ROS_WORKSPACE_ROOT:-/ros_ws}"
 ROS_DISTRO="${ROS_DISTRO:-jazzy}"
 ROS_SETUP_SCRIPT="${ROS_SETUP_SCRIPT:-/opt/ros/${ROS_DISTRO}/setup.bash}"

--- a/deps_rocker/extensions/ros_jazzy/underlay_build.sh
+++ b/deps_rocker/extensions/ros_jazzy/underlay_build.sh
@@ -29,19 +29,16 @@ else
     exit 1
 fi
 
-# Create build and install directories if they don't exist
-mkdir -p "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
-
-# Clean out any stale artifacts from previous builds
-if [ -n "$(ls -A "${UNDERLAY_BUILD}" 2>/dev/null)" ]; then
+# Clean out any stale artifacts from previous builds and recreate with correct permissions
+if [ -d "${UNDERLAY_BUILD}" ]; then
     rm -rf "${UNDERLAY_BUILD:?}/"*
 fi
-if [ -n "$(ls -A "${UNDERLAY_INSTALL}" 2>/dev/null)" ]; then
+if [ -d "${UNDERLAY_INSTALL}" ]; then
     rm -rf "${UNDERLAY_INSTALL:?}/"*
 fi
 
-# Set world-accessible permissions so container users can access
-chmod 777 "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
+# Create directories with world-accessible permissions in one step
+install -d -m 777 "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
 
 # Build underlay
 cd "${WORKSPACE_ROOT}"

--- a/deps_rocker/extensions/ros_jazzy/underlay_build.sh
+++ b/deps_rocker/extensions/ros_jazzy/underlay_build.sh
@@ -40,6 +40,9 @@ if [ -n "$(ls -A "${UNDERLAY_INSTALL}" 2>/dev/null)" ]; then
     rm -rf "${UNDERLAY_INSTALL:?}/"*
 fi
 
+# Set world-accessible permissions so container users can access
+chmod 777 "${UNDERLAY_BUILD}" "${UNDERLAY_INSTALL}"
+
 # Build underlay
 cd "${WORKSPACE_ROOT}"
 echo "Building packages from ${UNDERLAY_PATH}..."

--- a/deps_rocker/extensions/ros_jazzy/underlay_deps.sh
+++ b/deps_rocker/extensions/ros_jazzy/underlay_deps.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Use workspace layout from environment
-UNDERLAY_PATH="${ROS_UNDERLAY_PATH:-/ros_ws/underlay}"
+UNDERLAY_PATH="${ROS_UNDERLAY_PATH:-/ros_ws/underlay/src}"
 
 echo "Installing underlay dependencies"
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -342,7 +342,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.3.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.8-h2b335a9_101_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.9-h2b335a9_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
@@ -1197,10 +1197,10 @@ packages:
   purls: []
   size: 31547362
   timestamp: 1760367376467
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.8-h2b335a9_101_cp313.conda
-  build_number: 101
-  sha256: b429867f0faf5b9b71e2ebdbe8fedd6f84f4ba53fd2010a1f1458e1e1a038b98
-  md5: ae8cf86b9140c7b6a6593a582a8eab8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.9-h2b335a9_100_cp313.conda
+  build_number: 100
+  sha256: 317ee7a38f4cc97336a2aedf9c79e445adf11daa0d082422afa63babcd5117e4
+  md5: 78ba5c3a7aecc68ab3a9f396d3b69d06
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -1221,8 +1221,8 @@ packages:
   - tzdata
   license: Python-2.0
   purls: []
-  size: 37149783
-  timestamp: 1760366432739
+  size: 37323303
+  timestamp: 1760612239629
   python_site_packages_path: lib/python3.13/site-packages
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.0-h5989046_101_cp314.conda
   build_number: 101
@@ -1349,7 +1349,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml?source=compressed-mapping
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 204539
   timestamp: 1758892248166
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_0.conda

--- a/specs/01/ros-underlay-structure/plan.md
+++ b/specs/01/ros-underlay-structure/plan.md
@@ -1,0 +1,27 @@
+# Implementation Plan
+
+## 1. Update Environment Variables (ros_jazzy_snippet.Dockerfile)
+- Change `ROS_UNDERLAY_PATH` from `/ros_ws/underlay` to `/ros_ws/underlay/src`
+- Change `ROS_UNDERLAY_BUILD` from `/ros_ws/underlay_build` to `/ros_ws/underlay/build`
+- Change `ROS_UNDERLAY_INSTALL` from `/ros_ws/underlay_install` to `/ros_ws/underlay/install`
+- Add `ROS_UNDERLAY_LOG=/ros_ws/underlay/log`
+- Update mkdir commands to create new directory structure
+
+## 2. Update User Layer (ros_jazzy_user_snippet.Dockerfile)
+- Update VCS import to target `ROS_UNDERLAY_PATH` (which is now /ros_ws/underlay/src)
+- Cache path should be `/underlay` (without src, since vcs import structure is flat)
+- Copy destination should be `$ROS_UNDERLAY_PATH` (=/ros_ws/underlay/src)
+
+## 3. Update Build Scripts
+- underlay_build.sh: Update defaults to new paths
+- underlay_deps.sh: Update defaults to new paths
+
+## 4. Update Unit Tests (test_ros_jazzy_scripts.py)
+- Update path construction to match new structure
+- Change `underlay_path` to `underlay_path / "src"` where appropriate
+- Update directory assertions
+
+## 5. Testing
+- Run `pixi r test-extension ros_jazzy` (~15 min)
+- Verify all tests pass
+- Run `pixi r fix-commit-push`

--- a/specs/01/ros-underlay-structure/spec.md
+++ b/specs/01/ros-underlay-structure/spec.md
@@ -1,0 +1,16 @@
+# ROS Underlay Structure Update
+
+## Goal
+Update ROS workspace structure to use a cleaner layout: `/ros_ws/underlay/{src,build,install,log}` instead of separate `/ros_ws/{underlay,underlay_build,underlay_install}` directories.
+
+## Changes
+- `ROS_UNDERLAY_PATH` → `/ros_ws/underlay/src` (source files)
+- `ROS_UNDERLAY_BUILD` → `/ros_ws/underlay/build` (build artifacts)
+- `ROS_UNDERLAY_INSTALL` → `/ros_ws/underlay/install` (install prefix)
+- Add `ROS_UNDERLAY_LOG` → `/ros_ws/underlay/log` (build logs)
+
+## Affected Components
+- Environment variables in Dockerfile
+- Build scripts (underlay_build.sh, underlay_deps.sh)
+- User layer VCS import
+- Unit tests

--- a/specs/01/ros-underlay-structure/spec.md
+++ b/specs/01/ros-underlay-structure/spec.md
@@ -14,3 +14,6 @@ Update ROS workspace structure to use a cleaner layout: `/ros_ws/underlay/{src,b
 - Build scripts (underlay_build.sh, underlay_deps.sh)
 - User layer VCS import
 - Unit tests
+
+## Performance Optimization
+Replace slow `chmod -R 777` operations with `install -d -m 777` to set permissions at directory creation time, avoiding recursive permission changes.

--- a/test/test_ros_jazzy_scripts.py
+++ b/test/test_ros_jazzy_scripts.py
@@ -155,14 +155,14 @@ class TestRosJazzyScripts(unittest.TestCase):
         self.addCleanup(tmp_workspace.cleanup)
         workspace_root = Path(tmp_workspace.name) / "ros_ws"
         workspace_root.mkdir()
-        underlay_path = workspace_root / "underlay"
-        underlay_build = workspace_root / "underlay_build"
-        underlay_install = workspace_root / "underlay_install"
+        underlay_path = workspace_root / "underlay" / "src"
+        underlay_build = workspace_root / "underlay" / "build"
+        underlay_install = workspace_root / "underlay" / "install"
 
         # Create all required directories
-        underlay_path.mkdir()
-        underlay_build.mkdir()
-        underlay_install.mkdir()
+        underlay_path.mkdir(parents=True)
+        underlay_build.mkdir(parents=True)
+        underlay_install.mkdir(parents=True)
 
         pkg_dir = underlay_path / "dummy_pkg"
         pkg_dir.mkdir()


### PR DESCRIPTION
- Move underlay build from root layer to user layer in ros_jazzy_user_snippet.Dockerfile
- Remove complex ownership/permission handling from underlay_build.sh since it now runs in user context
- Simplify underlay_build.sh by removing ensure_owner_for_paths and ensure_world_accessible functions
- Dependencies are still installed during Docker build for caching, but build happens in user layer

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Move underlay workspace build to the user layer and simplify the build script by removing ownership and permission adjustments now that it runs in user context, while retaining dependency installation steps during Docker build for caching.

Enhancements:
- Relocate the underlay workspace build step from the root Docker layer to the user snippet Dockerfile
- Remove ensure_owner_for_paths and ensure_world_accessible functions from underlay_build.sh since builds now run as the non-root user
- Simplify underlay_build.sh by dropping complex ownership/permission logic and cleaning stale artifacts directly
- Keep underlay_deps.sh in the root Docker build with apt and rosdep cache mounts for improved layer caching