### PR TITLE
update pixi to use workspace

### DIFF
--- a/deps_rocker/extensions/auto/auto.py
+++ b/deps_rocker/extensions/auto/auto.py
@@ -94,7 +94,10 @@ class Auto(RockerExtension):
         # Use only patterns from auto_detect.yml files for all extensions
         tasks = [
             (self._detect_exact_dir, (workspace, dir_patterns, check_home)),
-            (self._detect_glob_patterns, (workspace, file_patterns, exclude_content_patterns)),
+            (
+                self._detect_glob_patterns,
+                (workspace, file_patterns, exclude_content_patterns, content_search_patterns),
+            ),
             (self._detect_content_search, (workspace, content_search_patterns)),
         ]
 
@@ -168,7 +171,9 @@ class Auto(RockerExtension):
                 )
         return found
 
-    def _detect_glob_patterns(self, workspace, file_patterns, exclude_content_patterns):
+    def _detect_glob_patterns(
+        self, workspace, file_patterns, exclude_content_patterns, content_search_patterns
+    ):
         import time
         import os
         import fnmatch
@@ -198,7 +203,6 @@ class Auto(RockerExtension):
                 except Exception as e:
                     walk_errors.append(e)
         # Match patterns in memory
-        content_search_patterns = getattr(self, "_content_search_patterns", {})
         for pattern, ext in file_patterns.items():
             start = time.time()
             # Support both basename patterns (e.g., "package.xml") and full path patterns (e.g., ".cargo/config.toml")

--- a/deps_rocker/extensions/pixi/auto_detect.yaml
+++ b/deps_rocker/extensions/pixi/auto_detect.yaml
@@ -2,7 +2,5 @@
 
 files:
   - "pixi.toml"
-  - "pyproject.toml":
-      content_search:
-        - "[tool.pixi.workspace]"
-        - "[tool.pixi.project]"
+  - pyproject.toml:
+      content_search: "\\[tool\\.pixi"

--- a/deps_rocker/extensions/pixi/auto_detect.yaml
+++ b/deps_rocker/extensions/pixi/auto_detect.yaml
@@ -3,4 +3,6 @@
 files:
   - "pixi.toml"
   - "pyproject.toml":
-      content_search: "[tool.pixi.project]"
+      content_search:
+        - "[tool.pixi.workspace]"
+        - "[tool.pixi.project]"

--- a/deps_rocker/extensions/pixi/auto_detect.yaml
+++ b/deps_rocker/extensions/pixi/auto_detect.yaml
@@ -4,6 +4,5 @@ files:
   - "pixi.toml"
   - pyproject.toml:
       content_search:
-        - "\\[tool\\.pixi\\.project\\]"
-        - "\\[tool\\.pixi\\.workspace\\]"
-        - "\\[tool\\.pixi\\]"
+        - "^\\[tool\\.pixi\\.project\\]"
+        - "^\\[tool\\.pixi\\.workspace\\]"

--- a/deps_rocker/extensions/pixi/auto_detect.yaml
+++ b/deps_rocker/extensions/pixi/auto_detect.yaml
@@ -3,4 +3,7 @@
 files:
   - "pixi.toml"
   - pyproject.toml:
-      content_search: "\\[tool\\.pixi"
+      content_search:
+        - "\\[tool\\.pixi\\.project\\]"
+        - "\\[tool\\.pixi\\.workspace\\]"
+        - "\\[tool\\.pixi\\]"

--- a/pixi.lock
+++ b/pixi.lock
@@ -601,7 +601,7 @@ packages:
 - pypi: ./
   name: deps-rocker
   version: 0.23.1
-  sha256: 57e3b64b588491b507c5cb90c15371af223a02057963858117b7ba43e5a7e4f9
+  sha256: 48df5db35707d792d4061cca2b0fbeb3241f4cce3c51a2f9b8968182e26c499e
   requires_dist:
   - rocker>=0.2.19
   - off-your-rocker>=0.1.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -43,7 +43,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py314h9891dd4_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl
@@ -121,7 +121,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py310h03d9f68_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl
@@ -201,7 +201,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311hdf67eae_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl
@@ -279,7 +279,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl
@@ -355,7 +355,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py313h7037e92_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl
@@ -1549,9 +1549,9 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.3-pyhd8ed1ab_0.conda
-  sha256: af9662662648f7f57c0a79afee98e393dacf68887c40aea1eec68b48afebb724
-  md5: bf0dc4c8a32e91290e3fae5403798c63
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
+  sha256: 77193c99c6626c58446168d3700f9643d8c0dab1f6deb6b9dd039e6872781bfb
+  md5: cfccfd4e8d9de82ed75c8e2c91cab375
   depends:
   - distlib >=0.3.7,<1
   - filelock >=3.12.2,<4
@@ -1562,8 +1562,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/virtualenv?source=compressed-mapping
-  size: 4380205
-  timestamp: 1760134237380
+  size: 4401341
+  timestamp: 1761726489722
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ pre-commit = ">=4,<4.4"
 Source = "https://github.com/blooop/deps_rocker"
 Home = "https://github.com/blooop/deps_rocker"
 
-[tool.pixi.project]
+[tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
 

--- a/test/test_auto_detect_comprehensive.py
+++ b/test/test_auto_detect_comprehensive.py
@@ -159,7 +159,7 @@ replace-with = "vendored-sources"
     def test_content_search_detection(self):
         """Test that content search works with quoted filenames"""
         setup_files = {
-            "pyproject.toml": """[tool.pixi]
+            "pyproject.toml": """[tool.pixi.project]
 dependencies = ["python"]
 
 [project]
@@ -167,7 +167,7 @@ name = "test"
 """,
             "main.py": "print('hello')",  # Need a .py file to trigger uv
         }
-        # Should detect both pixi due to [tool.pixi] section and uv due to pyproject.toml + .py file
+        # Should detect both pixi due to [tool.pixi.project] section and uv due to pyproject.toml + .py file
         expected = {"pixi", "uv"}
         self._test_detection_in_dir(setup_files, expected)
 

--- a/test/test_auto_detect_comprehensive.py
+++ b/test/test_auto_detect_comprehensive.py
@@ -44,7 +44,7 @@ class TestAutoDetectYmlQuoting(unittest.TestCase):
         # Use the auto path argument and disable home checking for test isolation
         # Test detection - use the internal method to get only directly detected extensions
         direct_detected = self.auto._detect_files_in_workspace(
-            {"auto": self.test_dir}, check_home=False
+            _cliargs={"auto": self.test_dir}, check_home=False
         )
 
         # Now all detected extensions should be from workspace only

--- a/test/test_auto_extension.py
+++ b/test/test_auto_extension.py
@@ -54,7 +54,7 @@ class TestAutoExtension(unittest.TestCase):
         def setup():
             subdir = Path("subdir")
             subdir.mkdir(exist_ok=True)
-            # Create pyproject.toml WITHOUT [tool.pixi] and WITH a .py file to trigger uv
+            # Create pyproject.toml WITHOUT [tool.pixi.project] and WITH a .py file to trigger uv
             with open(subdir / "pyproject.toml", "w", encoding="utf-8") as f:
                 f.write("[project]\nname = 'test'\n")
             with open(subdir / "main.py", "w", encoding="utf-8") as f:

--- a/test/test_auto_extension.py
+++ b/test/test_auto_extension.py
@@ -7,11 +7,11 @@ from deps_rocker.extensions.auto.auto import Auto
 
 class TestAutoExtension(unittest.TestCase):
     def test_content_search_debug(self):
-        """Test that content search for '[tool.pixi]' only enables pixi when present, and prints debug info."""
+        """Test that content search for '[tool.pixi.project]' only enables pixi when present, and prints debug info."""
 
         def setup_with_section():
             with open("pyproject.toml", "w", encoding="utf-8") as f:
-                f.write("[tool.pixi]\nfoo = 'bar'\n")
+                f.write("[tool.pixi.project]\nfoo = 'bar'\n")
 
         def setup_without_section():
             with open("pyproject.toml", "w", encoding="utf-8") as f:
@@ -199,11 +199,11 @@ class TestAutoExtension(unittest.TestCase):
             os.chdir(original_dir)
 
     def test_detect_pixi_pyproject_with_section(self):
-        """Test detection of pyproject.toml with [tool.pixi] section for pixi"""
+        """Test detection of pyproject.toml with [tool.pixi.project] section for pixi"""
 
         def setup():
             with open("pyproject.toml", "w", encoding="utf-8") as f:
-                f.write("[tool.pixi]\nfoo = 'bar'\n")
+                f.write("[tool.pixi.project]\nfoo = 'bar'\n")
 
         def assertion(deps):
             self.assertIn("pixi", deps)
@@ -211,7 +211,7 @@ class TestAutoExtension(unittest.TestCase):
         self._test_in_dir(setup, assertion)
 
     def test_detect_pixi_pyproject_without_section(self):
-        """Test detection of pyproject.toml without [tool.pixi] section for pixi (should not activate)"""
+        """Test detection of pyproject.toml without [tool.pixi.project] section for pixi (should not activate)"""
 
         def setup():
             with open("pyproject.toml", "w", encoding="utf-8") as f:

--- a/test/test_auto_extension.py
+++ b/test/test_auto_extension.py
@@ -343,6 +343,18 @@ class TestAutoExtension(unittest.TestCase):
         finally:
             os.chdir(original_dir)
 
+    def _test_in_dir_with_transitive(self, setup_func, assertion_func):
+        """Helper to run a test in the test directory with transitive dependencies"""
+        original_dir = os.getcwd()
+        try:
+            os.chdir(self.test_dir)
+            setup_func()
+            # Use required() to get both direct and transitive dependencies
+            deps = self.auto.required({"auto": self.test_dir})
+            assertion_func(deps)
+        finally:
+            os.chdir(original_dir)
+
     def test_transitive_dependencies_collected(self):
         """Test that transitive dependencies are properly collected"""
 
@@ -356,7 +368,8 @@ class TestAutoExtension(unittest.TestCase):
             # curl should be included as npm's transitive dependency
             self.assertIn("curl", deps)
 
-        self._test_in_dir(setup, assertion)
+        # This test needs to use required() to get transitive dependencies
+        self._test_in_dir_with_transitive(setup, assertion)
 
 
 if __name__ == "__main__":

--- a/test/test_auto_extension.py
+++ b/test/test_auto_extension.py
@@ -193,7 +193,10 @@ class TestAutoExtension(unittest.TestCase):
         try:
             os.chdir(self.test_dir)
             setup_func()
-            deps = self.auto.required({})
+            # Use _detect_files_in_workspace to avoid home directory detection
+            deps = self.auto._detect_files_in_workspace(
+                _cliargs={"auto": self.test_dir}, check_home=False
+            )
             assertion_func(deps)
         finally:
             os.chdir(original_dir)

--- a/test/test_auto_extension.py
+++ b/test/test_auto_extension.py
@@ -193,10 +193,8 @@ class TestAutoExtension(unittest.TestCase):
         try:
             os.chdir(self.test_dir)
             setup_func()
-            # Use _detect_files_in_workspace to avoid home directory detection
-            deps = self.auto._detect_files_in_workspace(
-                _cliargs={"auto": self.test_dir}, check_home=False
-            )
+            # Use required() method to detect dependencies
+            deps = self.auto.required({"auto": self.test_dir})
             assertion_func(deps)
         finally:
             os.chdir(original_dir)

--- a/test_all_extensions_subdirs.py
+++ b/test_all_extensions_subdirs.py
@@ -73,15 +73,12 @@ def test_all_extension_subdirectory_detection():
             "uv": "requirements.txt files",
         }
 
-        success = True
         for ext, description in expected_detections.items():
             if ext in detected:
                 print(f"✅ SUCCESS: {ext} detected from {description} in subdirectories")
             else:
                 print(f"❌ FAILED: {ext} NOT detected from {description} in subdirectories")
-                success = False
-
-        return success
+                assert False, f"{ext} NOT detected from {description} in subdirectories"
 
     finally:
         os.chdir(original_dir)
@@ -91,8 +88,8 @@ def test_all_extension_subdirectory_detection():
 
 
 if __name__ == "__main__":
-    success = test_all_extension_subdirectory_detection()
-    if success:
+    try:
+        test_all_extension_subdirectory_detection()
         print("\n🎉 ALL extensions now properly detect files in subdirectories!")
-    else:
-        print("\n💥 Some extensions still have subdirectory detection issues!")
+    except AssertionError as e:
+        print(f"\n💥 Some extensions still have subdirectory detection issues: {e}")


### PR DESCRIPTION
## Summary by Sourcery

Switch pixi configuration to use the workspace section and update auto-detection accordingly

Enhancements:
- Add support for detecting the [tool.pixi.workspace] section in auto_detect.yaml
- Rename the pixi config section in pyproject.toml from [tool.pixi.project] to [tool.pixi.workspace]