### PR TITLE
Feature/cache permissions

### DIFF
--- a/deps_rocker/extensions/cache_perms/__init__.py
+++ b/deps_rocker/extensions/cache_perms/__init__.py
@@ -1,0 +1,3 @@
+from .cache_perms import CachePerms
+
+__all__ = ["CachePerms"]

--- a/deps_rocker/extensions/cache_perms/cache_perms.py
+++ b/deps_rocker/extensions/cache_perms/cache_perms.py
@@ -1,0 +1,32 @@
+import os
+import pwd
+import logging
+from deps_rocker.simple_rocker_extension import SimpleRockerExtension
+
+
+class CachePerms(SimpleRockerExtension):
+    """Ensure .cache directory exists with proper permissions for the container user"""
+
+    name = "cache_perms"
+    depends_on_extension = ("user",)
+
+    def get_snippet(self, cliargs) -> str:
+        """
+        Add a Dockerfile snippet to create .cache with proper ownership.
+        This ensures the user can create and use cache directories (e.g., for uv, pip, etc.)
+        """
+        container_home = cliargs.get("user_home_dir") or pwd.getpwuid(os.getuid()).pw_dir
+        username = cliargs.get("user_name") or pwd.getpwuid(os.getuid()).pw_name
+        uid = cliargs.get("user_uid") or os.getuid()
+        gid = cliargs.get("user_gid") or os.getgid()
+
+        return f"""
+# Ensure .cache directory exists with proper ownership for user
+RUN mkdir -p "{container_home}/.cache" && \\
+    chown {uid}:{gid} "{container_home}/.cache" && \\
+    chmod 755 "{container_home}/.cache"
+"""
+
+    def invoke_after(self, cliargs) -> set:
+        """Run after user extension is set up"""
+        return {"user"}

--- a/deps_rocker/extensions/cache_perms/cache_perms.py
+++ b/deps_rocker/extensions/cache_perms/cache_perms.py
@@ -1,30 +1,37 @@
 import os
 import pwd
-import logging
 from deps_rocker.simple_rocker_extension import SimpleRockerExtension
 
 
 class CachePerms(SimpleRockerExtension):
-    """Ensure .cache directory exists with proper permissions for the container user"""
+    """Ensure .cache directory exists with proper permissions for the container user
+
+    This extension creates ~/.cache in the Dockerfile (as root) with 755 permissions,
+    which allows the user to write to it. This is necessary for tools like uv, pip, etc.
+    to create cache subdirectories without permission errors.
+
+    This must run BEFORE other extensions that mount subdirectories under .cache
+    (like claude), so the parent directory exists with correct permissions before
+    the volume mount overrides it.
+    """
 
     name = "cache_perms"
     depends_on_extension = ("user",)
 
     def get_snippet(self, cliargs) -> str:
         """
-        Add a Dockerfile snippet to create .cache with proper ownership.
-        This ensures the user can create and use cache directories (e.g., for uv, pip, etc.)
+        Create .cache directory owned by the user with proper permissions.
+        This ensures the directory exists before volume mounts, preventing Docker
+        from creating it with restrictive permissions. We can't use chown in the
+        root snippet, so we use world-writable permissions.
         """
         container_home = cliargs.get("user_home_dir") or pwd.getpwuid(os.getuid()).pw_dir
-        username = cliargs.get("user_name") or pwd.getpwuid(os.getuid()).pw_name
-        uid = cliargs.get("user_uid") or os.getuid()
-        gid = cliargs.get("user_gid") or os.getgid()
 
         return f"""
-# Ensure .cache directory exists with proper ownership for user
-RUN mkdir -p "{container_home}/.cache" && \\
-    chown {uid}:{gid} "{container_home}/.cache" && \\
-    chmod 755 "{container_home}/.cache"
+# Create .cache directory with world-writable permissions
+# This must exist before volume mounts so Docker doesn't create it as root
+# We use 777 to allow the user to write, since we can't easily chown in root context
+RUN mkdir -p "{container_home}/.cache" && chmod 777 "{container_home}/.cache"
 """
 
     def invoke_after(self, cliargs) -> set:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ cwd_name = "deps_rocker.extensions.cwd.cwd:CWDName"
 
 #utils
 auto = "deps_rocker.extensions.auto.auto:Auto"
+cache_perms = "deps_rocker.extensions.cache_perms.cache_perms:CachePerms"
 curl = "deps_rocker.extensions.curl.curl:Curl"
 locales = "deps_rocker.extensions.locales.locales:Locales"
 tzdata = "deps_rocker.extensions.tzdata.tzdata:TzData"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add a CachePerms extension to create the ~/.cache directory in the Dockerfile with world-writable permissions before volume mounts