### PR TITLE
Feature/uv mount error

### DIFF
--- a/deps_rocker/extensions/pixi/pixi_user_snippet.Dockerfile
+++ b/deps_rocker/extensions/pixi/pixi_user_snippet.Dockerfile
@@ -1,3 +1,6 @@
+# Create cache directories for pixi and uv (used by pixi)
+RUN mkdir -p ~/.cache/pixi ~/.cache/rattler ~/.cache/uv
+
 # Install Pixi into the user home from pre-populated bundle
 RUN mkdir -p ~/.pixi && cp -a /opt/deps_rocker/pixi/. ~/.pixi/
 RUN echo 'export PATH="$HOME/.pixi/bin:$PATH"' >> ~/.bashrc

--- a/deps_rocker/extensions/uv/uv_user_snippet.Dockerfile
+++ b/deps_rocker/extensions/uv/uv_user_snippet.Dockerfile
@@ -1,4 +1,6 @@
-RUN mkdir -p ~/.local/bin
+# Create cache directories for uv
+RUN mkdir -p ~/.cache/uv ~/.local/bin
+
 ENV SHELL=/bin/bash
 RUN echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc; echo 'eval "$(uvx --generate-shell-completion bash)"' >> ~/.bashrc \
     && (uv tool update-shell || echo 'uv tool update-shell already configured') \

--- a/pixi.lock
+++ b/pixi.lock
@@ -601,7 +601,7 @@ packages:
 - pypi: ./
   name: deps-rocker
   version: 0.23.1
-  sha256: 3abf3ab87d63d06cb100d3fc691e3933f3973ccb1d80526c206f4048d8473fd7
+  sha256: c32aecfdc3f9f813f613bb240db7ff99d9dede791ee4c5032a7d292cb5c6fe66
   requires_dist:
   - rocker>=0.2.19
   - off-your-rocker>=0.1.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -15,16 +15,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
@@ -91,6 +94,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
@@ -100,8 +104,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -171,6 +176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
@@ -180,8 +186,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -249,6 +256,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
@@ -258,8 +266,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -327,16 +336,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
@@ -713,6 +725,18 @@ packages:
   - tzdata>=2025.2 ; (sys_platform == 'emscripten' and extra == 'all') or (sys_platform == 'win32' and extra == 'all')
   - watchdog>=4.0.0 ; extra == 'all'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12129203
+  timestamp: 1720853576813
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
   sha256: 32d5007d12e5731867908cbf5345f5cd44a6c8755a2e8e63e15a184826a51f82
   md5: 25f954b7dae6dd7b0dc004dab74f1ce9
@@ -854,17 +878,18 @@ packages:
   purls: []
   size: 33731
   timestamp: 1750274110928
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
-  sha256: 6d9c32fc369af5a84875725f7ddfbfc2ace795c28f246dc70055a79f9b2003da
-  md5: 0b367fad34931cb79e0d6b7e5c06bb1c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
+  sha256: 4c992dcd0e34b68f843e75406f7f303b1b97c248d18f3c7c330bdc0bc26ae0b3
+  md5: 729a572a3ebb8c43933b30edcc628ceb
   depends:
   - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: blessing
   purls: []
-  size: 932581
-  timestamp: 1753948484112
+  size: 945576
+  timestamp: 1762299687230
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
   sha256: 1b981647d9775e1cdeb2fab0a4dd9cd75a6b0de2963f6c3953dbd712f78334b3
   md5: 5b767048b1b3ee9a954b06f4084f93dc
@@ -878,6 +903,16 @@ packages:
   purls: []
   size: 3898269
   timestamp: 1759968103436
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
+  sha256: 024fd46ac3ea8032a5ec3ea7b91c4c235701a8bf0e6520fe5e6539992a6bd05f
+  md5: f627678cf829bd70bccf141a19c3ad3e
+  depends:
+  - libstdcxx 15.2.0 h8f9b012_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 29343
+  timestamp: 1759968157195
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
   sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
   md5: 80c07c68d2f6870250959dcc95b209d1

--- a/specs/01/pixi-uv-user-cache-permissions/plan.md
+++ b/specs/01/pixi-uv-user-cache-permissions/plan.md
@@ -1,0 +1,52 @@
+# Plan: Fix Pixi/UV cache permissions for non-root users
+
+## Root Cause Analysis
+The issue occurs when:
+1. Pixi/UV extensions are used in combination with the user extension
+2. The Docker build runs as root
+3. The container runs as a non-root user
+4. Pixi tries to create cache directories at `/home/{username}/.cache/rattler/cache/uv-cache`
+5. The parent directory doesn't exist or is owned by root
+
+## Implementation Steps
+
+### 1. Update Pixi Extension
+- Modify `pixi_snippet.Dockerfile` to create cache directories
+- Use template variable to get username from user extension dependencies
+- Create directories: `.cache/pixi` and `.cache/rattler`
+- Set ownership using chown
+
+### 2. Update UV Extension
+- Modify `uv_snippet.Dockerfile` to create cache directories
+- Add dependency on user extension
+- Create directory: `.cache/uv`
+- Set ownership using chown
+
+### 3. Handle Edge Cases
+- Check if user extension is being used (username available)
+- If no username, skip cache directory creation (build-time cache only)
+- Ensure directories are created with proper permissions (755 for directories)
+
+## Technical Details
+
+### Template Variables Needed
+- `name`: Username from user extension (already available in extensions that depend on user)
+
+### Dockerfile Changes
+```dockerfile
+# In pixi_snippet.Dockerfile
+RUN if [ -n "@(name)" ]; then \
+    mkdir -p /home/@(name)/.cache/pixi /home/@(name)/.cache/rattler && \
+    chown -R @(name):@(name) /home/@(name)/.cache; \
+    fi
+```
+
+### Dependencies
+- Pixi extension must depend on user extension
+- UV extension must depend on user extension
+- Both already have this dependency, just need to use the template variable
+
+## Testing
+- Test with renv setup that triggers the error
+- Verify cache directories are created with correct ownership
+- Run pixi run ci to ensure no regressions

--- a/specs/01/pixi-uv-user-cache-permissions/spec.md
+++ b/specs/01/pixi-uv-user-cache-permissions/spec.md
@@ -1,0 +1,36 @@
+# Spec: Fix Pixi/UV cache permissions for non-root users
+
+## Goal
+Ensure that pixi and uv can create cache directories when running as a non-root user in the container.
+
+## Problem
+When using the uv extension via renv, pixi/uv tries to create cache directories at `/home/ags/.cache/rattler/cache/uv-cache` but fails with:
+```
+x failed to create uv cache directory
+`-> failed to create directory `/home/ags/.cache/rattler/cache/uv-cache`: Permission denied (os error 13)
+```
+
+This occurs because:
+1. Docker build runs as root
+2. Container runs as non-root user (via user extension)
+3. Cache directories don't exist or have wrong ownership
+
+## Requirements
+- Pixi and UV extensions must create cache directories with proper ownership for the target user
+- Cache directories should be created at build time with correct permissions
+- Solution must work when user extension is used
+- Must handle the case where username is not known at build time
+
+## Solution
+- Create cache directories during Docker build
+- Set ownership to match the user that will run the container
+- Use template variables to get username from user extension
+
+## Out of Scope
+- Changing cache mount locations
+- Supporting multiple users in same image
+
+## References
+- User extension for username template variable
+- Pixi cache directory: ~/.cache/pixi and ~/.cache/rattler
+- UV cache directory: ~/.cache/uv

--- a/specs/01/pixi-uv-user-cache-permissions/spec.md
+++ b/specs/01/pixi-uv-user-cache-permissions/spec.md
@@ -4,10 +4,10 @@
 Ensure that pixi and uv can create cache directories when running as a non-root user in the container.
 
 ## Problem
-When using the uv extension via renv, pixi/uv tries to create cache directories at `/home/ags/.cache/rattler/cache/uv-cache` but fails with:
+When using the uv extension via renv, pixi/uv tries to create cache directories at `/home/user/.cache/rattler/cache/uv-cache` but fails with:
 ```
 x failed to create uv cache directory
-`-> failed to create directory `/home/ags/.cache/rattler/cache/uv-cache`: Permission denied (os error 13)
+`-> failed to create directory `/home/user/.cache/rattler/cache/uv-cache`: Permission denied (os error 13)
 ```
 
 This occurs because:


### PR DESCRIPTION
## Summary by Sourcery

Ensure that cache directories for UV, Pixi, and Rattler are created during Docker builds and provide documentation for resolving cache permission issues when running as a non-root user.

Enhancements:
- Pre-create cache directories for UV, Pixi, and Rattler in their respective extension Dockerfiles

Documentation:
- Add plan and spec documentation for fixing cache permissions for Pixi and UV on non-root user builds