### PR TITLE
update to vcs2l

### DIFF
--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -10,12 +10,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
     apt-get update && apt-get install -y --no-install-recommends \
     ros-jazzy-ros-core \
-    python3-vcstool \
     python3-rosdep
 
 # Install colcon tooling, numpy, and lark via pip
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    pip install colcon-common-extensions colcon-defaults colcon-runner colcon-clean numpy lark --break-system-packages
+    pip install vcs2l colcon-common-extensions colcon-defaults colcon-runner colcon-clean numpy lark --break-system-packages
 
 ENV ROS_DISTRO=jazzy
 ENV AMENT_PREFIX_PATH=/opt/ros/jazzy


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace the python3-vcstool apt package with the vcs2l pip package in the ROS jazzy snippet Dockerfile