### PR TITLE
Feature/fzf builder

### DIFF
--- a/deps_rocker/extensions/fzf/fzf.py
+++ b/deps_rocker/extensions/fzf/fzf.py
@@ -6,6 +6,7 @@ class Fzf(SimpleRockerExtension):
 
     name = "fzf"
     depends_on_extension = ["git_clone", "curl", "user"]
+    builder_apt_packages = ["git", "curl", "ca-certificates"]
 
     # Template arguments for both snippets
     empy_args = {

--- a/deps_rocker/extensions/fzf/fzf_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/fzf/fzf_builder_snippet.Dockerfile
@@ -3,9 +3,27 @@ ARG FZF_VERSION=@FZF_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 
-ADD https://github.com/junegunn/fzf.git#master /tmp/fzf
-
-RUN bash -c "set -euxo pipefail && \
+# Use cache mount for git clone and fzf installation
+RUN --mount=type=cache,target=/root/.cache/fzf-repo,id=fzf-repo-cache \
+    --mount=type=cache,target=/root/.fzf-install,id=fzf-install-cache \
+    bash -c "set -euxo pipefail && \
+    # Clone or update repo in cache
+    CACHE_DIR='/root/.cache/fzf-repo' && \
+    if [ -d \"\$CACHE_DIR/.git\" ]; then \
+        cd \"\$CACHE_DIR\" && \
+        git fetch origin master && \
+        git reset --hard origin/master; \
+    else \
+        mkdir -p \"\$CACHE_DIR\" && \
+        git clone https://github.com/junegunn/fzf.git \"\$CACHE_DIR\"; \
+    fi && \
+    # Copy to fzf install location and run installer with --bin flag
+    mkdir -p /root/.fzf-install && \
+    rm -rf /root/.fzf-install/* && \
+    cp -a \"\$CACHE_DIR/.\" /root/.fzf-install/ && \
+    cd /root/.fzf-install && \
+    ./install --bin && \
+    # Copy completed installation to output directory
     OUTPUT_DIR='@(f"{builder_output_dir}")' && \
-    mkdir -p \"\$OUTPUT_DIR\" && \
-    cp -a /tmp/fzf \"\$OUTPUT_DIR/fzf\""
+    mkdir -p \"\$OUTPUT_DIR/fzf\" && \
+    cp -a /root/.fzf-install/. \"\$OUTPUT_DIR/fzf/\""

--- a/deps_rocker/extensions/fzf/fzf_user_snippet.Dockerfile
+++ b/deps_rocker/extensions/fzf/fzf_user_snippet.Dockerfile
@@ -1,6 +1,9 @@
-# Install fzf from staged source
+# Install fzf from staged source (binary already present from builder stage)
 RUN rm -rf ~/.fzf && mkdir -p ~/.fzf && cp -a /opt/deps_rocker/fzf/. ~/.fzf/
-RUN ~/.fzf/install --all
 
-# Add cdfzf function to bashrc
-RUN echo 'cdfzf() { file="$(fzf)"; [ -n "$file" ] && cd "$(dirname "$file")"; }' >> ~/.bashrc
+# Set up completion and key-bindings by sourcing shell files directly (no install script)
+RUN echo '# fzf setup' >> ~/.bashrc && \
+    echo 'export PATH="$HOME/.fzf/bin:$PATH"' >> ~/.bashrc && \
+    echo '[ -f ~/.fzf/shell/completion.bash ] && source ~/.fzf/shell/completion.bash' >> ~/.bashrc && \
+    echo '[ -f ~/.fzf/shell/key-bindings.bash ] && source ~/.fzf/shell/key-bindings.bash' >> ~/.bashrc && \
+    echo 'cdfzf() { file="$(fzf)"; [ -n "$file" ] && cd "$(dirname "$file")"; }' >> ~/.bashrc

--- a/deps_rocker/extensions/pixi/pixi.py
+++ b/deps_rocker/extensions/pixi/pixi.py
@@ -10,5 +10,5 @@ class Pixi(SimpleRockerExtension):
 
     # Template arguments for both snippets
     empy_args = {
-        "PIXI_VERSION": "0.55.0",
+        "PIXI_VERSION": "0.59.0",
     }

--- a/pixi.lock
+++ b/pixi.lock
@@ -601,7 +601,7 @@ packages:
 - pypi: ./
   name: deps-rocker
   version: 0.23.1
-  sha256: 3abf3ab87d63d06cb100d3fc691e3933f3973ccb1d80526c206f4048d8473fd7
+  sha256: c32aecfdc3f9f813f613bb240db7ff99d9dede791ee4c5032a7d292cb5c6fe66
   requires_dist:
   - rocker>=0.2.19
   - off-your-rocker>=0.1.0

--- a/specs/02/fzf-builder-caching/plan.md
+++ b/specs/02/fzf-builder-caching/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: FZF Builder Stage Caching
+
+## Current Flow
+1. Builder stage: Clone fzf repo with `ADD https://github.com/junegunn/fzf.git#master`
+2. Builder stage: Copy repo to output directory
+3. Main stage: Copy from builder to `/opt/deps_rocker/fzf`
+4. User stage: Copy to `~/.fzf` and run `~/.fzf/install --all`
+   - **Issue**: Install script downloads binary from GitHub releases here
+
+## Proposed Flow
+1. Builder stage: Clone fzf repo using cache mount
+2. Builder stage: Download fzf binary using cache mount (if not already cached)
+3. Builder stage: Create directory structure with repo + binary
+4. Main stage: Copy from builder to `/opt/deps_rocker/fzf`
+5. User stage: Copy to `~/.fzf` (binary already present) and run install script
+   - Install script detects binary and skips download
+
+## File Changes
+
+### `fzf_builder_snippet.Dockerfile`
+```dockerfile
+# syntax=docker/dockerfile:1.4
+ARG FZF_VERSION=@FZF_VERSION@
+
+@(f"FROM {base_image} AS {builder_stage}")
+
+# Use cache mount for git clone
+RUN --mount=type=cache,target=/root/.cache/fzf-repo,id=fzf-repo-cache \
+    bash -c "set -euxo pipefail && \
+    CACHE_DIR='/root/.cache/fzf-repo' && \
+    if [ -d \"\$CACHE_DIR/.git\" ]; then \
+        cd \"\$CACHE_DIR\" && \
+        git fetch origin master && \
+        git reset --hard origin/master; \
+    else \
+        mkdir -p \"\$CACHE_DIR\" && \
+        git clone https://github.com/junegunn/fzf.git \"\$CACHE_DIR\"; \
+    fi && \
+    OUTPUT_DIR='@(f"{builder_output_dir}")' && \
+    mkdir -p \"\$OUTPUT_DIR/fzf\" && \
+    cp -a \"\$CACHE_DIR/.\" \"\$OUTPUT_DIR/fzf/\""
+
+# Pre-download fzf binary with cache mount
+RUN --mount=type=cache,target=/root/.cache/fzf-bins,id=fzf-bins-cache \
+    bash -c "set -euxo pipefail && \
+    VERSION=\"${FZF_VERSION}\" && \
+    ARCH=\$(uname -m) && \
+    case \"\$ARCH\" in \
+        x86_64) FZF_ARCH='linux_amd64' ;; \
+        aarch64) FZF_ARCH='linux_arm64' ;; \
+        armv7l) FZF_ARCH='linux_armv7' ;; \
+        *) echo \"Unsupported architecture: \$ARCH\"; exit 1 ;; \
+    esac && \
+    CACHE_FILE=\"/root/.cache/fzf-bins/fzf-\${VERSION}-\${FZF_ARCH}.tar.gz\" && \
+    if [ ! -f \"\$CACHE_FILE\" ]; then \
+        echo \"Downloading fzf \${VERSION} for \${FZF_ARCH}...\" && \
+        curl -fL \"https://github.com/junegunn/fzf/releases/download/v\${VERSION}/fzf-\${VERSION}-\${FZF_ARCH}.tar.gz\" \
+            -o \"\$CACHE_FILE\"; \
+    else \
+        echo \"Using cached fzf binary: \$CACHE_FILE\"; \
+    fi && \
+    OUTPUT_DIR='@(f"{builder_output_dir}")' && \
+    mkdir -p \"\$OUTPUT_DIR/fzf/bin\" && \
+    tar -xzf \"\$CACHE_FILE\" -C \"\$OUTPUT_DIR/fzf/bin/\""
+```
+
+### No changes needed for:
+- `fzf_snippet.Dockerfile` (main stage copy)
+- `fzf_user_snippet.Dockerfile` (install script will detect binary)
+- `fzf.py` (no logic changes)
+
+## Testing
+1. First build: Should download binary and cache it
+2. Second build: Should reuse cached binary (much faster)
+3. Verify `fzf --version` shows correct version in container
+4. Test fzf functionality (Ctrl-R, Ctrl-T, etc.)
+
+## Notes
+- The fzf install script checks for `~/.fzf/bin/fzf` and skips download if present
+- Binary must match the architecture of the final container image
+- Cache is keyed by version in filename, so updating FZF_VERSION will trigger new download

--- a/specs/02/fzf-builder-caching/plan.md
+++ b/specs/02/fzf-builder-caching/plan.md
@@ -9,11 +9,11 @@
 
 ## Proposed Flow
 1. Builder stage: Clone fzf repo using cache mount
-2. Builder stage: Download fzf binary using cache mount (if not already cached)
-3. Builder stage: Create directory structure with repo + binary
+2. Builder stage: Use cache mount for fzf home, run `./install --bin` to download binary
+3. Builder stage: Copy repo + binary to output directory
 4. Main stage: Copy from builder to `/opt/deps_rocker/fzf`
-5. User stage: Copy to `~/.fzf` (binary already present) and run install script
-   - Install script detects binary and skips download
+5. User stage: Copy to `~/.fzf` (binary already present) and run `./install --all`
+   - Install script detects binary and only sets up shell integration
 
 ## File Changes
 
@@ -24,9 +24,11 @@ ARG FZF_VERSION=@FZF_VERSION@
 
 @(f"FROM {base_image} AS {builder_stage}")
 
-# Use cache mount for git clone
+# Use cache mount for git clone and fzf installation
 RUN --mount=type=cache,target=/root/.cache/fzf-repo,id=fzf-repo-cache \
+    --mount=type=cache,target=/root/.fzf-install,id=fzf-install-cache \
     bash -c "set -euxo pipefail && \
+    # Clone or update repo in cache
     CACHE_DIR='/root/.cache/fzf-repo' && \
     if [ -d \"\$CACHE_DIR/.git\" ]; then \
         cd \"\$CACHE_DIR\" && \
@@ -36,32 +38,16 @@ RUN --mount=type=cache,target=/root/.cache/fzf-repo,id=fzf-repo-cache \
         mkdir -p \"\$CACHE_DIR\" && \
         git clone https://github.com/junegunn/fzf.git \"\$CACHE_DIR\"; \
     fi && \
+    # Copy to fzf install location and run installer with --bin flag
+    mkdir -p /root/.fzf-install && \
+    rm -rf /root/.fzf-install/* && \
+    cp -a \"\$CACHE_DIR/.\" /root/.fzf-install/ && \
+    cd /root/.fzf-install && \
+    ./install --bin && \
+    # Copy completed installation to output directory
     OUTPUT_DIR='@(f"{builder_output_dir}")' && \
     mkdir -p \"\$OUTPUT_DIR/fzf\" && \
-    cp -a \"\$CACHE_DIR/.\" \"\$OUTPUT_DIR/fzf/\""
-
-# Pre-download fzf binary with cache mount
-RUN --mount=type=cache,target=/root/.cache/fzf-bins,id=fzf-bins-cache \
-    bash -c "set -euxo pipefail && \
-    VERSION=\"${FZF_VERSION}\" && \
-    ARCH=\$(uname -m) && \
-    case \"\$ARCH\" in \
-        x86_64) FZF_ARCH='linux_amd64' ;; \
-        aarch64) FZF_ARCH='linux_arm64' ;; \
-        armv7l) FZF_ARCH='linux_armv7' ;; \
-        *) echo \"Unsupported architecture: \$ARCH\"; exit 1 ;; \
-    esac && \
-    CACHE_FILE=\"/root/.cache/fzf-bins/fzf-\${VERSION}-\${FZF_ARCH}.tar.gz\" && \
-    if [ ! -f \"\$CACHE_FILE\" ]; then \
-        echo \"Downloading fzf \${VERSION} for \${FZF_ARCH}...\" && \
-        curl -fL \"https://github.com/junegunn/fzf/releases/download/v\${VERSION}/fzf-\${VERSION}-\${FZF_ARCH}.tar.gz\" \
-            -o \"\$CACHE_FILE\"; \
-    else \
-        echo \"Using cached fzf binary: \$CACHE_FILE\"; \
-    fi && \
-    OUTPUT_DIR='@(f"{builder_output_dir}")' && \
-    mkdir -p \"\$OUTPUT_DIR/fzf/bin\" && \
-    tar -xzf \"\$CACHE_FILE\" -C \"\$OUTPUT_DIR/fzf/bin/\""
+    cp -a /root/.fzf-install/. \"\$OUTPUT_DIR/fzf/\""
 ```
 
 ### No changes needed for:

--- a/specs/02/fzf-builder-caching/plan.md
+++ b/specs/02/fzf-builder-caching/plan.md
@@ -17,43 +17,20 @@
 
 ## File Changes
 
+### `fzf.py`
+- Add `builder_apt_packages = ["git", "curl", "ca-certificates"]`
+- This automatically injects apt install into builder stage
+
 ### `fzf_builder_snippet.Dockerfile`
-```dockerfile
-# syntax=docker/dockerfile:1.4
-ARG FZF_VERSION=@FZF_VERSION@
-
-@(f"FROM {base_image} AS {builder_stage}")
-
-# Use cache mount for git clone and fzf installation
-RUN --mount=type=cache,target=/root/.cache/fzf-repo,id=fzf-repo-cache \
-    --mount=type=cache,target=/root/.fzf-install,id=fzf-install-cache \
-    bash -c "set -euxo pipefail && \
-    # Clone or update repo in cache
-    CACHE_DIR='/root/.cache/fzf-repo' && \
-    if [ -d \"\$CACHE_DIR/.git\" ]; then \
-        cd \"\$CACHE_DIR\" && \
-        git fetch origin master && \
-        git reset --hard origin/master; \
-    else \
-        mkdir -p \"\$CACHE_DIR\" && \
-        git clone https://github.com/junegunn/fzf.git \"\$CACHE_DIR\"; \
-    fi && \
-    # Copy to fzf install location and run installer with --bin flag
-    mkdir -p /root/.fzf-install && \
-    rm -rf /root/.fzf-install/* && \
-    cp -a \"\$CACHE_DIR/.\" /root/.fzf-install/ && \
-    cd /root/.fzf-install && \
-    ./install --bin && \
-    # Copy completed installation to output directory
-    OUTPUT_DIR='@(f"{builder_output_dir}")' && \
-    mkdir -p \"\$OUTPUT_DIR/fzf\" && \
-    cp -a /root/.fzf-install/. \"\$OUTPUT_DIR/fzf/\""
-```
+- Remove manual apt install (handled by `builder_apt_packages`)
+- Add cache mounts for git repo and fzf installation
+- Clone/update repo in cache
+- Run `./install --bin` to download binary
+- Copy complete installation to output directory
 
 ### No changes needed for:
 - `fzf_snippet.Dockerfile` (main stage copy)
-- `fzf_user_snippet.Dockerfile` (install script will detect binary)
-- `fzf.py` (no logic changes)
+- `fzf_user_snippet.Dockerfile` (runs `./install --all` which detects existing binary and only sets up shell integration)
 
 ## Testing
 1. First build: Should download binary and cache it

--- a/specs/02/fzf-builder-caching/spec.md
+++ b/specs/02/fzf-builder-caching/spec.md
@@ -1,0 +1,22 @@
+# Spec: FZF Builder Stage Caching
+
+## Problem
+The fzf extension currently re-downloads the fzf binary from GitHub releases on every build during the user install step (`~/.fzf/install --all`), even though the builder stage already clones the repository. This wastes time and network bandwidth.
+
+## Solution
+Move the binary download to the builder stage using BuildKit cache mounts:
+1. Cache the git repository clone
+2. Pre-download the versioned fzf binary (matching `FZF_VERSION`) in the builder stage
+3. Copy both repo and binary to builder output directory
+4. In user stage, the install script will find the pre-downloaded binary and skip the download
+
+## Implementation Details
+- Use `RUN --mount=type=cache,target=/root/.cache/fzf` for binary downloads
+- Download architecture-appropriate binary based on `uname -m` and `FZF_VERSION`
+- Keep binaries in cache with versioned filenames (e.g., `fzf-${VERSION}-${ARCH}.tar.gz`)
+- Install script will detect existing `~/.fzf/bin/fzf` binary and skip download
+
+## Benefits
+- Significantly faster builds (skip ~5-10MB download per build)
+- Works offline after first download
+- Still respects FZF_VERSION for updates


### PR DESCRIPTION
## Summary by Sourcery

Implement BuildKit caching for the fzf extension’s builder stage to reuse the cloned repository and pre-downloaded binary, streamline the user snippet to skip redundant downloads by sourcing shell integration directly, configure necessary builder packages, and bump the default Pixi version.

Enhancements:
- Introduce BuildKit cache mounts in fzf builder Dockerfile to cache the git repository and downloaded binary for faster rebuilds
- Simplify fzf user snippet to skip re-downloading the binary and directly source shell completion and key-binding scripts
- Add builder_apt_packages configuration to the fzf extension for automatic installation of git, curl, and ca-certificates
- Bump default PIXI_VERSION from 0.55.0 to 0.59.0 in the Pixi extension

Documentation:
- Add implementation plan and specification files for fzf builder caching under specs/02/fzf-builder-caching