### PR TITLE
Fix claude test script to explicitly use --help flag

### DIFF
--- a/deps_rocker/extensions/claude/test.sh
+++ b/deps_rocker/extensions/claude/test.sh
@@ -19,7 +19,7 @@ which claude || true
 claude --version
 
 # Ensure help executes without triggering first-time setup
-HELP_OUT=$(claude 2>&1 | head -n 50 || true)
+HELP_OUT=$(claude --help 2>&1 | head -n 50 || true)
 echo "$HELP_OUT" | sed 's/.*/[HELP] &/'
 # Fail on onboarding phrases that indicate first-run experience or tips block
 if echo "$HELP_OUT" | grep -E "[Ff]irst[[:space:]-]*time" >/dev/null || \


### PR DESCRIPTION
The Claude CLI now requires explicit arguments. Changed the test script to use 'claude --help' instead of just 'claude' to avoid the error: 'Input must be provided either through stdin or as a prompt argument when using --print'

This fixes the CI failure where the test was failing with this error.

## Summary by Sourcery

Bug Fixes:
- Update the Claude test script to call `claude --help` explicitly to avoid missing input errors