### PR TITLE
fix flaky ci

### DIFF
--- a/deps_rocker/extensions/ros_jazzy/build_underlay.sh
+++ b/deps_rocker/extensions/ros_jazzy/build_underlay.sh
@@ -41,6 +41,7 @@ colcon build \
     --build-base "$UNDERLAY_BUILD" \
     --install-base "$UNDERLAY_INSTALL" \
     --merge-install \
+    --event-handlers console_direct+ \
     --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 echo "Underlay built successfully!"

--- a/deps_rocker/extensions/ros_jazzy/underlay_build.sh
+++ b/deps_rocker/extensions/ros_jazzy/underlay_build.sh
@@ -56,6 +56,7 @@ colcon build \
     --build-base "$UNDERLAY_BUILD" \
     --install-base "$UNDERLAY_INSTALL" \
     --merge-install \
+    --event-handlers console_direct+ \
     --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 echo "Underlay built successfully!"

--- a/test/fixtures/ros_jazzy_smoke_test.sh
+++ b/test/fixtures/ros_jazzy_smoke_test.sh
@@ -66,7 +66,8 @@ colcon build \
     --packages-select test_package \
     --build-base "$build_base" \
     --install-base "$install_base" \
-    --merge-install
+    --merge-install \
+    --event-handlers console_direct+
 
 if [ ! -f "${install_base}/setup.bash" ]; then
     echo "ERROR: Expected workspace setup file at ${install_base}/setup.bash"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add `--event-handlers console_direct+` to colcon build commands in smoke test and underlay scripts to improve log streaming and CI reliability.