### PR TITLE
Claude/palanteer builder pattern 011 c uq6gs sa gog1h72ki4 f xe

### DIFF
--- a/deps_rocker/extensions/palanteer/palanteer.py
+++ b/deps_rocker/extensions/palanteer/palanteer.py
@@ -6,11 +6,25 @@ class Palanteer(SimpleRockerExtension):
 
     name = "palanteer"
     depends_on_extension = ("curl", "git_clone", "x11")
-    apt_packages = [
+
+    # Build-time dependencies for compiling palanteer
+    builder_apt_packages = [
         "build-essential",
         "cmake",
         "python3-dev",
         "python3-pip",
+        "libgl1-mesa-dev",
+        "libglu1-mesa-dev",
+        "libx11-dev",
+        "libxrandr-dev",
+        "libxinerama-dev",
+        "libxcursor-dev",
+        "libxi-dev",
+        "git",
+    ]
+
+    # Runtime dependencies (libraries needed to run palanteer binaries)
+    apt_packages = [
         "libgl1-mesa-dev",
         "libglu1-mesa-dev",
         "libx11-dev",

--- a/deps_rocker/extensions/palanteer/palanteer.py
+++ b/deps_rocker/extensions/palanteer/palanteer.py
@@ -13,6 +13,7 @@ class Palanteer(SimpleRockerExtension):
         "cmake",  # build system
         "python3-dev",  # Python headers for building bindings
         "git",  # for cloning repository
+        "ca-certificates",  # for HTTPS git cloning
         # Library headers needed for compilation
         "libgl1-mesa-dev",
         "libglu1-mesa-dev",

--- a/deps_rocker/extensions/palanteer/palanteer.py
+++ b/deps_rocker/extensions/palanteer/palanteer.py
@@ -27,6 +27,7 @@ class Palanteer(SimpleRockerExtension):
     apt_packages = [
         "libgl1",  # OpenGL runtime library
         "libglu1-mesa",  # GLU runtime library
+        "libgl1-mesa-dri",  # Mesa DRI drivers (includes GPU drivers and software renderer)
         "libx11-6",  # X11 runtime library
         "libxrandr2",  # Xrandr runtime library
         "libxinerama1",  # Xinerama runtime library

--- a/deps_rocker/extensions/palanteer/palanteer.py
+++ b/deps_rocker/extensions/palanteer/palanteer.py
@@ -9,10 +9,11 @@ class Palanteer(SimpleRockerExtension):
 
     # Build-time dependencies for compiling palanteer
     builder_apt_packages = [
-        "build-essential",
-        "cmake",
-        "python3-dev",
-        "python3-pip",
+        "build-essential",  # gcc, g++, make
+        "cmake",  # build system
+        "python3-dev",  # Python headers for building bindings
+        "git",  # for cloning repository
+        # Library headers needed for compilation
         "libgl1-mesa-dev",
         "libglu1-mesa-dev",
         "libx11-dev",
@@ -20,16 +21,15 @@ class Palanteer(SimpleRockerExtension):
         "libxinerama-dev",
         "libxcursor-dev",
         "libxi-dev",
-        "git",
     ]
 
-    # Runtime dependencies (libraries needed to run palanteer binaries)
+    # Runtime dependencies (shared libraries only, no headers)
     apt_packages = [
-        "libgl1-mesa-dev",
-        "libglu1-mesa-dev",
-        "libx11-dev",
-        "libxrandr-dev",
-        "libxinerama-dev",
-        "libxcursor-dev",
-        "libxi-dev",
+        "libgl1",  # OpenGL runtime library
+        "libglu1-mesa",  # GLU runtime library
+        "libx11-6",  # X11 runtime library
+        "libxrandr2",  # Xrandr runtime library
+        "libxinerama1",  # Xinerama runtime library
+        "libxcursor1",  # Xcursor runtime library
+        "libxi6",  # Xi runtime library
     ]

--- a/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Use a fixed base image for the builder to maximize cache sharing across all projects
 # The compiled binaries will work across different final images with compatible glibc
-FROM ubuntu:24.04 AS @(builder_stage)
+@(f"FROM ubuntu:24.04 AS {builder_stage}")
 
 # Clone and build palanteer using BuildKit cache for both git repo and build artifacts
 RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-cache \

--- a/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Use a fixed base image for the builder to maximize cache sharing across all projects
 # The compiled binaries will work across different final images with compatible glibc
-@(f"FROM ubuntu:24.04 AS {builder_stage}")
+@(f"FROM {base_image} AS {builder_stage}")
 
 # Clone and build palanteer using BuildKit cache for both git repo and build artifacts
 RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-cache \
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-
         cd /tmp/palanteer && \
         mkdir -p build && cd build && \
         cmake .. -DCMAKE_BUILD_TYPE=Release && \
-        make -j$(nproc) && \
+        make -j$(nproc) palanteer && \
         # Cache the build artifacts \
         rm -rf /root/.cache/palanteer-build-cache/bin && \
         cp -r bin /root/.cache/palanteer-build-cache/ && \

--- a/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.4
-@(f"FROM {base_image} AS {builder_stage}")
+# Use a fixed base image for the builder to maximize cache sharing across all projects
+# The compiled binaries will work across different final images with compatible glibc
+FROM ubuntu:24.04 AS @(builder_stage)
 
 # Clone and build palanteer using BuildKit cache for both git repo and build artifacts
 RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-cache \

--- a/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.4
+@(f"FROM {base_image} AS {builder_stage}")
+
+# Clone and build palanteer using BuildKit cache for both git repo and build artifacts
+RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-cache \
+    --mount=type=cache,target=/root/.cache/palanteer-build-cache,id=palanteer-build-cache \
+    bash -c 'set -euxo pipefail && \
+    OUTPUT_DIR="@(f"{builder_output_dir}")" && \
+    mkdir -p /root/.cache/palanteer-git-cache /root/.cache/palanteer-build-cache "$OUTPUT_DIR" && \
+    \
+    # Clone or update palanteer repository in cache \
+    if [ -d /root/.cache/palanteer-git-cache/palanteer ]; then \
+        cd /root/.cache/palanteer-git-cache/palanteer && \
+        git fetch --depth 1 origin && \
+        git reset --hard origin/master; \
+    else \
+        git clone --depth 1 https://github.com/dfeneyrou/palanteer.git /root/.cache/palanteer-git-cache/palanteer; \
+    fi && \
+    \
+    # Get the current commit hash to detect if we need to rebuild \
+    cd /root/.cache/palanteer-git-cache/palanteer && \
+    CURRENT_COMMIT=$(git rev-parse HEAD) && \
+    BUILD_MARKER="/root/.cache/palanteer-build-cache/build_commit.txt" && \
+    \
+    # Check if we already built this exact commit \
+    if [ -f "$BUILD_MARKER" ] && [ "$(cat $BUILD_MARKER)" = "$CURRENT_COMMIT" ] && [ -d /root/.cache/palanteer-build-cache/bin ]; then \
+        echo "Build artifacts for commit $CURRENT_COMMIT already cached, skipping build"; \
+    else \
+        echo "Building palanteer from commit $CURRENT_COMMIT"; \
+        # Copy source to temp location for building \
+        cp -r /root/.cache/palanteer-git-cache/palanteer /tmp/palanteer && \
+        cd /tmp/palanteer && \
+        mkdir -p build && cd build && \
+        cmake .. -DCMAKE_BUILD_TYPE=Release && \
+        make -j$(nproc) && \
+        # Cache the build artifacts \
+        rm -rf /root/.cache/palanteer-build-cache/bin && \
+        cp -r bin /root/.cache/palanteer-build-cache/ && \
+        echo "$CURRENT_COMMIT" > "$BUILD_MARKER" && \
+        cd /tmp && rm -rf palanteer; \
+    fi && \
+    \
+    # Copy cached build artifacts to output directory \
+    cp -r /root/.cache/palanteer-build-cache/bin/* "$OUTPUT_DIR/"'

--- a/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
+++ b/deps_rocker/extensions/palanteer/palanteer_builder_snippet.Dockerfile
@@ -13,8 +13,8 @@ RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-
     # Clone or update palanteer repository in cache \
     if [ -d /root/.cache/palanteer-git-cache/palanteer ]; then \
         cd /root/.cache/palanteer-git-cache/palanteer && \
-        git fetch --depth 1 origin && \
-        git reset --hard origin/master; \
+        git fetch --depth 1 origin main && \
+        git reset --hard FETCH_HEAD; \
     else \
         git clone --depth 1 https://github.com/dfeneyrou/palanteer.git /root/.cache/palanteer-git-cache/palanteer; \
     fi && \

--- a/deps_rocker/extensions/palanteer/palanteer_snippet.Dockerfile
+++ b/deps_rocker/extensions/palanteer/palanteer_snippet.Dockerfile
@@ -1,22 +1,10 @@
+# syntax=docker/dockerfile:1.4
 
+# Copy palanteer binaries from builder stage
+@(f"COPY --from={builder_stage} {builder_output_dir}/* /usr/local/bin/")
 
-# Clone and build palanteer using BuildKit cache for the git repo (use root-owned cache dir)
-RUN --mount=type=cache,target=/root/.cache/palanteer-git-cache,id=palanteer-git-cache \
-    cd /tmp && \
-    if [ -d /root/.cache/palanteer-git-cache/palanteer ]; then \
-        cd /root/.cache/palanteer-git-cache/palanteer && \
-        git fetch --depth 1 origin && \
-        git reset --hard origin/master; \
-    else \
-        git clone --depth 1 https://github.com/dfeneyrou/palanteer.git /root/.cache/palanteer-git-cache/palanteer; \
-    fi && \
-    cp -r /root/.cache/palanteer-git-cache/palanteer /tmp/palanteer && \
-    cd /tmp/palanteer && \
-    mkdir build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release && \
-    make -j$(nproc) && \
-    cp bin/* /usr/local/bin/ && \
-    cd /tmp && rm -rf palanteer
+# Ensure binaries are executable
+RUN chmod +x /usr/local/bin/palanteer* || true
 
 # Update PATH to include /usr/local/bin
 ENV PATH="/usr/local/bin:${PATH}"

--- a/specs/01/palanteer-builder-pattern/plan.md
+++ b/specs/01/palanteer-builder-pattern/plan.md
@@ -1,0 +1,50 @@
+# Implementation Plan: Palanteer Builder Pattern
+
+## 1. Update palanteer.py
+- Add `builder_apt_packages` attribute with build-time dependencies:
+  - build-essential
+  - cmake
+  - python3-dev
+  - libgl1-mesa-dev
+  - libglu1-mesa-dev
+  - libx11-dev
+  - libxrandr-dev
+  - libxinerama-dev
+  - libxcursor-dev
+  - libxi-dev
+- Keep only runtime dependencies in `apt_packages` (if any are needed)
+- These dependencies are currently all for building
+
+## 2. Create palanteer_builder_snippet.Dockerfile
+This will contain:
+- FROM base_image AS palanteer_builder
+- Cache mount for git repository (already exists in current implementation)
+- Cache mount for build artifacts (NEW)
+- Clone/update palanteer repository
+- Compile with cmake and make
+- Place binaries in builder output directory (`/opt/deps_rocker/palanteer`)
+
+Key improvements:
+- Cache the compiled binaries, not just the source
+- Build artifacts persist across Docker builds
+- Only rebuild when source changes
+
+## 3. Update palanteer_snippet.Dockerfile
+Simplify to:
+- COPY binaries from builder stage
+- Set PATH if needed
+
+## 4. Testing Strategy
+- Build a Docker image with palanteer extension
+- Verify binaries are installed and functional
+- Build again without changes to verify caching works
+- Run existing test.sh to ensure functionality
+
+## Pattern Reference
+Following the same approach as:
+- `lazygit`: Downloads binary and caches it
+- `nvim`: Downloads binary and caches it
+- `urdf_viz`: Downloads binary and caches it
+- But for palanteer we compile from source like some Rust projects
+
+The key insight: Cache the *compiled artifacts*, not just the source code.

--- a/specs/01/palanteer-builder-pattern/plan.md
+++ b/specs/01/palanteer-builder-pattern/plan.md
@@ -17,7 +17,7 @@
 
 ## 2. Create palanteer_builder_snippet.Dockerfile
 This will contain:
-- FROM base_image AS palanteer_builder
+- FROM ubuntu:24.04 AS palanteer_builder (FIXED base image for global cache sharing)
 - Cache mount for git repository (already exists in current implementation)
 - Cache mount for build artifacts (NEW)
 - Clone/update palanteer repository
@@ -28,6 +28,7 @@ Key improvements:
 - Cache the compiled binaries, not just the source
 - Build artifacts persist across Docker builds
 - Only rebuild when source changes
+- **Fixed builder base image ensures cache sharing across ALL projects** (doesn't matter what final image you're building)
 
 ## 3. Update palanteer_snippet.Dockerfile
 Simplify to:

--- a/specs/01/palanteer-builder-pattern/spec.md
+++ b/specs/01/palanteer-builder-pattern/spec.md
@@ -1,0 +1,23 @@
+# Palanteer Builder Pattern
+
+## Goal
+Refactor the palanteer extension to use a builder pattern to cache compilation artifacts and avoid rebuilding on every Docker image build.
+
+## Current Issue
+The palanteer extension currently compiles from source in every Docker build, which is time-consuming. While the git repository is cached, the compilation step (cmake + make) runs every time.
+
+## Solution
+Use a multi-stage Dockerfile builder pattern where:
+1. **Builder stage** (`palanteer_builder_snippet.Dockerfile`): Compiles palanteer once and caches the build artifacts
+2. **Main stage** (`palanteer_snippet.Dockerfile`): Simply copies the pre-compiled binaries from the builder stage
+
+## Benefits
+- Faster builds when palanteer hasn't changed
+- Cleaner separation between build dependencies and runtime dependencies
+- Build artifacts are cached across Docker builds
+- Follows the established pattern used by other extensions (lazygit, urdf_viz, nvim)
+
+## Implementation Details
+- Move build-time dependencies to `builder_apt_packages`
+- Cache both the git repository AND the compiled binaries
+- Copy compiled binaries from builder stage to final image

--- a/specs/01/palanteer-builder-pattern/spec.md
+++ b/specs/01/palanteer-builder-pattern/spec.md
@@ -18,6 +18,8 @@ Use a multi-stage Dockerfile builder pattern where:
 - Follows the established pattern used by other extensions (lazygit, urdf_viz, nvim)
 
 ## Implementation Details
-- Move build-time dependencies to `builder_apt_packages`
+- Separate build-time and runtime dependencies:
+  - `builder_apt_packages`: Build tools (cmake, gcc) + library headers (-dev packages)
+  - `apt_packages`: Runtime libraries only (no -dev packages, smaller footprint)
 - Cache both the git repository AND the compiled binaries
 - Copy compiled binaries from builder stage to final image

--- a/specs/01/palanteer-builder-pattern/spec.md
+++ b/specs/01/palanteer-builder-pattern/spec.md
@@ -15,6 +15,7 @@ Use a multi-stage Dockerfile builder pattern where:
 - Faster builds when palanteer hasn't changed
 - Cleaner separation between build dependencies and runtime dependencies
 - Build artifacts are cached across Docker builds
+- **Global cache sharing**: Builder uses fixed Ubuntu 24.04 base image, so compilation cache is shared across ALL projects/repos regardless of their base image
 - Follows the established pattern used by other extensions (lazygit, urdf_viz, nvim)
 
 ## Implementation Details


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Palanteer extension to use a multi-stage Docker builder pattern that caches compilation artifacts and separates build-time and runtime dependencies, resulting in faster builds and slimmer runtime images.

New Features:
- Introduce builder_apt_packages in palanteer.py for build-time OS packages separate from runtime dependencies
- Add palanteer_builder_snippet.Dockerfile to clone, build, and cache Palanteer binaries in a dedicated builder stage
- Simplify palanteer_snippet.Dockerfile to copy prebuilt binaries from the builder stage and adjust executable permissions

Enhancements:
- Separate build-time and runtime apt dependencies to reduce the final image footprint
- Implement commit-based caching of build artifacts to skip rebuilding unchanged sources

Documentation:
- Add an implementation plan (plan.md) and specification (spec.md) documents detailing the builder pattern, caching strategy, and dependency separation