### PR TITLE
Claude/debug docker xauth issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,27 @@ script_test:
   - test.sh
 
 
+## Troubleshooting
+
+### X11 Extension: `.Xauthority does not exist` Error
+
+If you encounter this error when using the x11 extension:
+```
+xauth:  file /home/user/.Xauthority does not exist
+xauth: (argv):1:  unable to read any entries from file "(stdin)"
+```
+
+This occurs because the upstream rocker X11 extension expects `~/.Xauthority` to exist on the host system. The X11 extension runs `xauth nlist $DISPLAY` to copy X11 authentication entries into the container, but this command fails if the file doesn't exist.
+
+**Quick Fix:**
+```bash
+touch ~/.Xauthority
+```
+
+This creates an empty `.Xauthority` file. When you start X11 or log in again, the file will be populated with the appropriate authentication entries.
+
+**Alternative Solution:** If you don't need GUI support in your container, remove `x11` from your `rockerc.yaml` args list.
+
 ## limitations/TODO
 
 This has only been tested on the ubuntu base image. It assumes you have access to apt-get.

--- a/specs/03/x11-xauth-fix/plan.md
+++ b/specs/03/x11-xauth-fix/plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan: X11 Xauth Fix
+
+## Phase 1: Documentation (Immediate)
+
+### 1. Update README.md
+Add troubleshooting section for X11 extension:
+
+```markdown
+## Troubleshooting
+
+### X11 Extension: `.Xauthority does not exist` Error
+
+If you see this error:
+```
+xauth:  file /home/user/.Xauthority does not exist
+xauth: (argv):1:  unable to read any entries from file "(stdin)"
+```
+
+**Quick Fix:**
+```bash
+touch ~/.Xauthority
+```
+
+**Alternative:** If you don't need GUI support, remove `x11` from your `rockerc.yaml` args list.
+```
+
+### 2. Test the workaround
+- Verify `touch ~/.Xauthority` resolves the issue
+- Document any edge cases
+
+## Phase 2: Wrapper Extension (If Needed)
+
+### 1. Create `x11_safe` extension
+```python
+# deps_rocker/extensions/x11_safe/x11_safe.py
+class X11Safe(SimpleRockerExtension):
+    """Safely enable X11 by ensuring .Xauthority exists"""
+
+    name = "x11_safe"
+    depends_on_extension = ("x11",)
+
+    def invoke_before(self, args):
+        """Create .Xauthority if it doesn't exist before X11 extension runs"""
+        # Check and create ~/.Xauthority if missing
+        # Return appropriate docker RUN commands
+```
+
+### 2. Add entry point to pyproject.toml
+
+### 3. Create tests
+- Test with missing .Xauthority
+- Test with existing .Xauthority
+- Verify X11 extension still works
+
+### 4. Update documentation
+- Add x11_safe to available extensions list
+- Explain when to use x11_safe vs x11
+
+## Decision Point
+**Start with Phase 1 only.** Implement Phase 2 only if users request it or if the workaround proves insufficient.
+
+## Testing Strategy
+1. Remove ~/.Xauthority and test rocker with x11 extension
+2. Apply fix (touch ~/.Xauthority)
+3. Verify X11 forwarding works
+4. Document results

--- a/specs/03/x11-xauth-fix/spec.md
+++ b/specs/03/x11-xauth-fix/spec.md
@@ -1,0 +1,30 @@
+# X11 Xauth Missing .Xauthority Fix
+
+## Problem
+The rocker X11 extension fails when `~/.Xauthority` doesn't exist on the host system:
+```
+xauth:  file /home/ags/.Xauthority does not exist
+xauth: (argv):1:  unable to read any entries from file "(stdin)"
+```
+
+## Root Cause
+The upstream rocker X11 extension runs `xauth nlist $DISPLAY` which tries to read from `~/.Xauthority`. If this file doesn't exist, xauth fails.
+
+## Solution Options
+
+### Option 1: Documentation (Immediate)
+Document the workaround in deps_rocker README:
+- Create empty `.Xauthority`: `touch ~/.Xauthority`
+- Or remove x11 from rockerc.yaml if GUI not needed
+
+### Option 2: Wrapper Extension (Robust)
+Create a `x11_safe` deps_rocker extension that:
+1. Checks if `~/.Xauthority` exists
+2. Creates it if missing before invoking X11 extension
+3. Uses `depends_on_extension = ("x11",)` to ensure proper ordering
+
+### Option 3: Patch Upstream (Long-term)
+Submit PR to rocker to handle missing `.Xauthority` gracefully by checking file existence before running `xauth nlist`.
+
+## Recommended Approach
+Start with Option 1 (documentation), implement Option 2 if needed by users.

--- a/specs/03/x11-xauth-fix/spec.md
+++ b/specs/03/x11-xauth-fix/spec.md
@@ -12,10 +12,12 @@ The upstream rocker X11 extension runs `xauth nlist $DISPLAY` which tries to rea
 
 ## Solution Options
 
-### Option 1: Documentation (Immediate)
+### Option 1: Documentation (Immediate) ✅ COMPLETED
 Document the workaround in deps_rocker README:
 - Create empty `.Xauthority`: `touch ~/.Xauthority`
 - Or remove x11 from rockerc.yaml if GUI not needed
+
+**Status:** Implemented in README.md troubleshooting section
 
 ### Option 2: Wrapper Extension (Robust)
 Create a `x11_safe` deps_rocker extension that:

--- a/specs/03/x11-xauth-fix/spec.md
+++ b/specs/03/x11-xauth-fix/spec.md
@@ -3,7 +3,7 @@
 ## Problem
 The rocker X11 extension fails when `~/.Xauthority` doesn't exist on the host system:
 ```
-xauth:  file /home/ags/.Xauthority does not exist
+xauth:  file /home/user/.Xauthority does not exist
 xauth: (argv):1:  unable to read any entries from file "(stdin)"
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

Document a workaround for the Docker X11 extension failure caused by a missing ~/.Xauthority file and add accompanying implementation plan and specification for a potential wrapper extension.

Enhancements:
- Add a troubleshooting section to README for the Docker X11 extension failing due to missing .Xauthority file

Documentation:
- Document quick fix (`touch ~/.Xauthority`) and alternative (remove `x11` arg) for the X11 `.Xauthority does not exist` error
- Add an implementation plan (specs/03/x11-xauth-fix/plan.md) outlining documentation and optional wrapper extension phases
- Add a spec file (specs/03/x11-xauth-fix/spec.md) describing the X11 Xauth issue, root cause, solution options, and recommendation