### PR TITLE
need to set PIP_BREAK_SYSTEM_PACKAGES=1 or rosdep fails

### DIFF
--- a/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
+++ b/deps_rocker/extensions/ros_jazzy/ros_jazzy_snippet.Dockerfile
@@ -1,5 +1,6 @@
 # Generic ROS 2 Jazzy setup - works with any ROS repository
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Install ROS2 repository and key
 RUN add-apt-repository universe \

--- a/pixi.lock
+++ b/pixi.lock
@@ -612,8 +612,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: deps-rocker
-  version: 0.23.1
-  sha256: 81f26ce7123e3534af5ae7d50e0b46b6ddc4f7301c01cfb0393db6d8ce5fbb32
+  version: 0.23.2
+  sha256: 5d70eb384a3900c9f2786fcdf92f11a31c7fe5cf0c8394dcf60f0e29b080dae4
   requires_dist:
   - rocker>=0.2.19
   - off-your-rocker>=0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deps_rocker"
-version = "0.23.1"
+version = "0.23.2"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A rocker plugin to help installing apt and pip dependencies"
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure the Docker image environment to export PIP_BREAK_SYSTEM_PACKAGES=1 for ROS Jazzy builds.